### PR TITLE
Return codes match

### DIFF
--- a/GenIfaceDrivers/MCP23017Driver.h
+++ b/GenIfaceDrivers/MCP23017Driver.h
@@ -30,14 +30,14 @@
 	#define MCP23017_PORTIOCNT		8
 
 /*****	Definitions	*****/
-	typedef enum eMCP23017Returns_t {
-		MCP23017Warn_Unknown	= -1,	/**< An unknown but recoverable error occurred */
+	typedef enum eMCP23017Return_t {
+		MCP23017Warn_Unknown	= 1,	/**< An unknown but recoverable error occurred */
 		MCP23017_Success		= 0,	/**< Operation completed successfully */
-		MCP23017Fail_Unknown	= 1,	/**< An unknown and unrecoverable occured */
-		MCP23017Fail_InvalidPin	= 2,	/**< Pin requested is invalid */
-		MCP23017Fail_InvalidMode= 3,	/**< Pin mode requested is invalid */
-		MCP23017Fail_WrongMode	= 4,	/**< Output requested for Input pin*/
-		MCP23017Fail_BusError	= 5,	/**< Error reported from the I2C interface */
+		MCP23017Fail_Unknown	= -1,	/**< An unknown and unrecoverable occured */
+		MCP23017Fail_InvalidPin	= -2,	/**< Pin requested is invalid */
+		MCP23017Fail_InvalidMode= -3,	/**< Pin mode requested is invalid */
+		MCP23017Fail_WrongMode	= -4,	/**< Output requested for Input pin*/
+		MCP23017Fail_BusError	= -5,	/**< Error reported from the I2C interface */
 	} eMCP23017Returns_t;
 
 	/**	@brief		Values for the I2C address of the MCP23017

--- a/GenIfaceDrivers/TF02Driver.h
+++ b/GenIfaceDrivers/TF02Driver.h
@@ -29,14 +29,14 @@
 	/**	@brief		Enumeration of all error codes for the TF02 driver
 		@ingroup	tf02driver
 	*/
-	typedef enum eTF02Returns_t {
-		TF02Warn_Unreliable		= -2,	/**< A readign was read that was reported unreliable */
-		TFO2Warn_Unknown		= -1,	/**< An unknown but recoverable error occurred */
+	typedef enum eTF02Return_t {
+		TF02Warn_Unreliable		= 2,	/**< A readign was read that was reported unreliable */
+		TFO2Warn_Unknown		= 1,	/**< An unknown but recoverable error occurred */
 		TF02_Success			= 0,	/**< Operation completed successfully */
-		TF02Fail_Unknown		= 1,	/**< An unknown and unrecoverable error occurred */
-		TF02Fail_UART			= 2,	/**< The UART port reported a failure */
-		TF02Fail_NoData			= 3,	/**< Incomplete or no data received from device */
-		TF02Fail_Checksum		= 4,	/**< Data received had an invalidated checksum */
+		TF02Fail_Unknown		= -1,	/**< An unknown and unrecoverable error occurred */
+		TF02Fail_UART			= -2,	/**< The UART port reported a failure */
+		TF02Fail_NoData			= -3,	/**< Incomplete or no data received from device */
+		TF02Fail_Checksum		= -4,	/**< Data received had an invalidated checksum */
 	} eTF02Returns_t;
 	
 	/**	@brief		Structure for storage and parsing of data from TF02

--- a/GenIfaceDrivers/XBeeDriver.h
+++ b/GenIfaceDrivers/XBeeDriver.h
@@ -51,16 +51,16 @@
 #define XBEE_NODEIDLEN			10
 
 /***** Definitions	*****/
-typedef enum eXBeeResult_t {
-	XBWarn_NodeIDLen= -3,
-	XBWarn_NoMessage= -2,
-	XBWarn_NoData	= -2,
-	XBWarn_Unknown	= -1,
+typedef enum eXBeeReturn_t {
+	XBWarn_NodeIDLen= 3,
+	XBWarn_NoMessage= 2,
+	XBWarn_NoData	= 2,
+	XBWarn_Unknown	= 1,
 	XB_Success		= 0,
-	XBFail_Unknown	= 1,
-	XBFail_Checksum	= 2,
-	XBFail_MsgSize	= 3,
-} eXBeeResult_t;
+	XBFail_Unknown	= -1,
+	XBFail_Checksum	= -2,
+	XBFail_MsgSize	= -3,
+} eXBeeReturn_t;
 
 typedef enum eXBeeFrameIndexes_t {
 	XBIdx_Start				= 0,
@@ -245,25 +245,25 @@ typedef struct sXBeeNetDiscovResult_t {
 
 
 /***** Prototypes 	*****/
-eXBeeResult_t XBeeInitialize(sXBeeObject_t *pXbeeObj, sUARTIface_t *pUART, uint8_t nDTRPin, uint8_t nRstPin);
+eXBeeReturn_t XBeeInitialize(sXBeeObject_t *pXbeeObj, sUARTIface_t *pUART, uint8_t nDTRPin, uint8_t nRstPin);
 
 uint8_t XBeeAPIChecksum(uint8_t *paMsg);
 
-eXBeeResult_t XBeeReadMessage(sXBeeObject_t *pXbeeObj);
+eXBeeReturn_t XBeeReadMessage(sXBeeObject_t *pXbeeObj);
 
-eXBeeResult_t XBeeParseMessage(sXBeeObject_t *pXbeeObj, sXBeeFrameRecv_t *pFrameRecv);
+eXBeeReturn_t XBeeParseMessage(sXBeeObject_t *pXbeeObj, sXBeeFrameRecv_t *pFrameRecv);
 
-eXBeeResult_t XBeeParseNetworkDiscoveryData(const uint8_t *pATCmdData, sXBeeNetDiscovResult_t *pNetworkDevice);
+eXBeeReturn_t XBeeParseNetworkDiscoveryData(const uint8_t *pATCmdData, sXBeeNetDiscovResult_t *pNetworkDevice);
 
-eXBeeResult_t XBeeATQueryCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], uint8_t *pnFrameID);
+eXBeeReturn_t XBeeATQueryCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], uint8_t *pnFrameID);
 
-eXBeeResult_t XBeeATSetCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], uint32_t nValue, uint8_t *pnFrameID);
+eXBeeReturn_t XBeeATSetCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], uint32_t nValue, uint8_t *pnFrameID);
 
-eXBeeResult_t XBeeTXReqest(sXBeeObject_t *pXbeeObj, uint64_t nDestAddr, uint16_t nNetAddr, uint16_t nDataLen, const void *pData, uint8_t *pnFrameID);
+eXBeeReturn_t XBeeTXReqest(sXBeeObject_t *pXbeeObj, uint64_t nDestAddr, uint16_t nNetAddr, uint16_t nDataLen, const void *pData, uint8_t *pnFrameID);
 
 /***** Functions	*****/
 
-eXBeeResult_t XBeeInitialize(sXBeeObject_t *pXbeeObj, sUARTIface_t *pUART, uint8_t nDTRPin, uint8_t nRstPin) {
+eXBeeReturn_t XBeeInitialize(sXBeeObject_t *pXbeeObj, sUARTIface_t *pUART, uint8_t nDTRPin, uint8_t nRstPin) {
 	pXbeeObj->nDataReadyPin = nDTRPin;
 	pXbeeObj->nResetPin = nRstPin;
 	pXbeeObj->nFrameID = 1; //Must start at 1, zero means no reply needed
@@ -289,7 +289,7 @@ uint8_t XBeeAPIChecksum(uint8_t *paMsg) {
   return nCheckSum;
 }
 
-eXBeeResult_t XBeeReadMessage(sXBeeObject_t *pXbeeObj) {
+eXBeeReturn_t XBeeReadMessage(sXBeeObject_t *pXbeeObj) {
 	uint16_t nBytes, nRead, nCtr, nBuffIdx, nMsgLen;
 	
 	pXbeeObj->pUART->pfUARTDataAvailable(pXbeeObj->pUART, &nBytes);
@@ -378,7 +378,7 @@ eXBeeResult_t XBeeReadMessage(sXBeeObject_t *pXbeeObj) {
 	return XB_Success;
 }
 
-eXBeeResult_t XBeeParseMessage(sXBeeObject_t *pXbeeObj, sXBeeFrameRecv_t *pFrameRecv) {
+eXBeeReturn_t XBeeParseMessage(sXBeeObject_t *pXbeeObj, sXBeeFrameRecv_t *pFrameRecv) {
 	pFrameRecv->nDataLen = pXbeeObj->anDataBuffer[XBIdx_LengthMSB] << 8;
 	pFrameRecv->nDataLen |= pXbeeObj->anDataBuffer[XBIdx_LengthLSB];
 	
@@ -478,9 +478,9 @@ eXBeeResult_t XBeeParseMessage(sXBeeObject_t *pXbeeObj, sXBeeFrameRecv_t *pFrame
 	return XB_Success;
 }
 
-eXBeeResult_t XBeeParseNetworkDiscoveryData(const uint8_t *pATCmdData, sXBeeNetDiscovResult_t *pNetworkDevice) {
+eXBeeReturn_t XBeeParseNetworkDiscoveryData(const uint8_t *pATCmdData, sXBeeNetDiscovResult_t *pNetworkDevice) {
 	uint16_t nCtr;
-	eXBeeResult_t eRetVal = XB_Success;
+	eXBeeReturn_t eRetVal = XB_Success;
 	
 	//2 bytes are network address, MSB -> LSB
 	pNetworkDevice->nNetAddr = pATCmdData[0] << 8; //MSB
@@ -537,7 +537,7 @@ eXBeeResult_t XBeeParseNetworkDiscoveryData(const uint8_t *pATCmdData, sXBeeNetD
 	return eRetVal;
 }
 
-eXBeeResult_t XBeeATQueryCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], uint8_t *pnFrameID) {
+eXBeeReturn_t XBeeATQueryCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], uint8_t *pnFrameID) {
 	uint16_t nDataLen = 4; //Frame Type byte + ID byte + 2 AT command characters
 	
 	//Set values common to all frames
@@ -564,13 +564,13 @@ eXBeeResult_t XBeeATQueryCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], u
 	return XB_Success;
 }
 
-eXBeeResult_t XBeeATSetCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], uint32_t nValue, uint8_t *pnFrameID) {
+eXBeeReturn_t XBeeATSetCommand(sXBeeObject_t *pXbeeObj, const char ATCmd[2], uint32_t nValue, uint8_t *pnFrameID) {
 	
 	
 	return XB_Success;
 }
 
-eXBeeResult_t XBeeTXReqest(sXBeeObject_t *pXbeeObj, uint64_t nDestAddr, uint16_t nNetAddr, uint16_t nDataBytes, const void *pData, uint8_t *pnFrameID) {
+eXBeeReturn_t XBeeTXReqest(sXBeeObject_t *pXbeeObj, uint64_t nDestAddr, uint16_t nNetAddr, uint16_t nDataBytes, const void *pData, uint8_t *pnFrameID) {
 	uint16_t nDataLen = 14 + nDataBytes; //Frame Type byte + ID byte + 8 Dest addr + 2 net addr + 1 BCast + 1 Options + Data
 	
 	if (nDataLen > XBEE_DATABYTES) {

--- a/GenericLibs/I2CGeneralInterface.h
+++ b/GenericLibs/I2CGeneralInterface.h
@@ -81,15 +81,15 @@
 			hardware.  +/-26 through +/-100 are available for specific hardware imlementations.
 		@ingroup	i2ciface
 	*/		
-	typedef enum eI2CReturns_t {
-		I2C_Warn_PartialRead	= -2,
-		I2C_Warn_Unknown		= -1,	/**< An unknown warning occured communicating with the I2C port */
+	typedef enum eI2CReturn_t {
+		I2C_Warn_PartialRead	= 2,
+		I2C_Warn_Unknown		= 1,	/**< An unknown warning occured communicating with the I2C port */
 		I2C_Success				= 0,	/**< I2C communication completed successfully */
-		I2C_Fail_Unknown		= 1,	/**< An unknown failure occured communicating with the I2C port */
-		I2C_Fail_Unsupported	= 2,	/**< The requested I2C operation is not supported by this specified port */
-		I2C_Fail_WriteBuffOver	= 3,
-		I2C_Fail_NackAddr		= 4,
-		I2C_Fail_NackData		= 5,
+		I2C_Fail_Unknown		= -1,	/**< An unknown failure occured communicating with the I2C port */
+		I2C_Fail_Unsupported	= -2,	/**< The requested I2C operation is not supported by this specified port */
+		I2C_Fail_WriteBuffOver	= -3,
+		I2C_Fail_NackAddr		= -4,
+		I2C_Fail_NackData		= -5,
 	} eI2CReturns_t;
 	
 	/**	@brief		Enumeration of all capabilities this interface provides

--- a/GenericLibs/UARTGeneralInterface.h
+++ b/GenericLibs/UARTGeneralInterface.h
@@ -50,12 +50,12 @@
 
 	typedef struct sUARTIface_t sUARTIface_t;
 
-	typedef enum eUARTReturns_t {
-		UART_Warn_Timeout		= -2,	/**< An operation timed out, data transfer was ncomplete */
-		UART_Warn_Unknown		= -1,	/**< An unknown warning occured communicating with the UART port */
+	typedef enum eUARTReturn_t {
+		UART_Warn_Timeout		= 2,	/**< An operation timed out, data transfer was ncomplete */
+		UART_Warn_Unknown		= 1,	/**< An unknown warning occured communicating with the UART port */
 		UART_Success			= 0,	/**< UART communication completed successfully */
-		UART_Fail_Unknown		= 1,
-		UART_Fail_Unsupported	= 2,	/**< The requested UART operation is not supported by this specified port */
+		UART_Fail_Unknown		= -1,
+		UART_Fail_Unsupported	= -2,	/**< The requested UART operation is not supported by this specified port */
 	} eUARTReturns_t;
 	
 	typedef enum eUARTCapabilities_t {


### PR DESCRIPTION
Setting all return enums to follow the same convention.  Fail is negative and name is Return singular
Addresses issue #20 