### PR TITLE
APA102

### DIFF
--- a/GenIfaceDrivers/APA102Driver.c
+++ b/GenIfaceDrivers/APA102Driver.c
@@ -1,0 +1,93 @@
+/**	File:	APA102Driver.c
+	Author:	J. Beighel
+	Date:	2021-02-02
+*/
+
+/*****	Includes	*****/
+	#include "APA102Driver.h"
+
+/*****	Defines		*****/
+
+
+/*****	Definitions	*****/
+
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	#define APA102PositionRedByte(eOrder, nRed)		((nRed & APA102_ColorMask) << ((eOrder & APA102_ROrderMask) >> APA102_ROrderShift))
+	
+	#define APA102PositionBlueByte(eOrder, nBlue)		((nBlue & APA102_ColorMask) << ((eOrder & APA102_BOrderMask) >> APA102_BOrderShift))
+	
+	#define APA102PositionGreenByte(eOrder, nGreen)	((nGreen & APA102_ColorMask) << ((eOrder & APA102_GOrderMask) >> APA102_GOrderShift))
+
+/*****	Functions	*****/
+eAPA102Return_t APA102Initialize(sAPA102Info_t *pDev, sSPIIface_t *pSpiDev) {
+	pDev->pSpi = pSpiDev;
+	
+	pDev->eOrder = APA102_RBGOrder;
+	pDev->nLightNum = 11;
+	memset(pDev->anLights, 0, sizeof(uint32_t) * pDev->nLightNum);
+	
+	return Success;
+}
+
+eAPA102Return_t APA102SetLightColor(sAPA102Info_t *pDev, uint32_t nLightID, uint8_t nRed, uint8_t nGreen, uint8_t nBlue) {
+	uint32_t nLightVal = 0;
+	
+	nLightVal |= APA102PositionRedByte(pDev->eOrder, nRed);
+	nLightVal |= APA102PositionGreenByte(pDev->eOrder, nGreen);
+	nLightVal |= APA102PositionBlueByte(pDev->eOrder, nBlue);
+	
+	pDev->anLights[nLightID] = nLightVal;
+	
+	return Success;
+}
+
+eAPA102Return_t APA102UpdateLights(sAPA102Info_t *pDev) {
+	uint32_t nLightCtr;
+	uint8_t nByte, nDump;
+	
+	pDev->pSpi->pfBeginTransfer(pDev->pSpi);
+	
+	//Start frame
+	nByte = 0x00;
+	for (nLightCtr = 0; nLightCtr < 4; nLightCtr++) {
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+	}
+	
+	//Write the 3 byte color code for each light
+	for (nLightCtr = 0; nLightCtr < pDev->nLightNum; nLightCtr++) {
+		nByte = 0xFF; //Global brightness, fully on
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		
+		//Write lowest byte
+		nByte = pDev->anLights[nLightCtr] & 0xFF;
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		
+		//Write middle byte
+		nByte = (pDev->anLights[nLightCtr] >> 8) & 0xFF;
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		
+		//Write highest byte
+		nByte = (pDev->anLights[nLightCtr] >> 16) & 0xFF;
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+	}
+	
+	//End Frame
+	nByte = 0xFF;
+	for (nLightCtr = 0; nLightCtr < (pDev->nLightNum + 15) / 16; nLightCtr++) {
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+	}
+	
+	pDev->pSpi->pfEndTransfer(pDev->pSpi);
+	
+	return Success;
+}

--- a/GenIfaceDrivers/APA102Driver.h
+++ b/GenIfaceDrivers/APA102Driver.h
@@ -1,0 +1,67 @@
+/**	@defgroup	GROUPNAME
+	@brief		
+	@details	v
+	#Description
+	
+	#File Information
+		File:	APA102Driver.h
+		Author:	J. Beighel
+		Date:	2021-02-02
+*/
+
+#ifndef __APA102Driver_H
+	#define __APA102Driver_H
+
+/*****	Includes	*****/
+	#include <string.h>
+
+	#include "CommonUtils.h"
+	#include "SPIGeneralInterface.h"
+
+/*****	Defines		*****/
+	
+	
+/*****	Definitions	*****/
+	typedef eReturn_t	eAPA102Return_t;
+	
+	typedef enum eAPA102Light_t {
+		APA102_ROrderMask		= 0x00FF0000,
+		APA102_ROrderShift		= 16,
+		APA102_GOrderMask		= 0x0000FF00,
+		APA102_GOrderShift		= 8,
+		APA102_BOrderMask		= 0x000000FF,	/**< Mask of order to get Blue bytes */
+		APA102_BOrderShift		= 0,			/**< Number of LShifts to get Blue order */
+		
+		APA102_BRGOrder			= 0x00000810,	/**< Bit shifts to position bytes in BRG order */
+		APA102_RBGOrder			= 0x00100800,	/**< Bit shifts to position bytes in RBG order */
+		
+		APA102_ColorMask		= 0xFF,
+		
+		APA102_NumBits			= 24,			/**< Number of bits to send for each LED */
+	} eAPA102Light_t;
+	
+	typedef struct sAPA102Info_t {
+		sSPIIface_t *pSpi;		/**< Pointer to SPI interface */
+		eAPA102Light_t eOrder;		/**< Light order to use for this set */
+		uint32_t nLightNum;			/**< Number of lights being controlled */
+		uint32_t anLights[64];		/**< Array of light colors to write */
+	} sAPA102Info_t;
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	eAPA102Return_t APA102Initialize(sAPA102Info_t *pDev, sSPIIface_t *pSpiDev);
+	
+	eAPA102Return_t APA102SetLightColor(sAPA102Info_t *pDev, uint32_t nLightID, uint8_t nRed, uint8_t nGreen, uint8_t nBlue);
+	
+	eAPA102Return_t APA102UpdateLights(sAPA102Info_t *pDev);
+
+/*****	Functions	*****/
+
+
+#endif
+

--- a/Projects/APA102led/APA102Driver.c
+++ b/Projects/APA102led/APA102Driver.c
@@ -1,0 +1,93 @@
+/**	File:	APA102Driver.c
+	Author:	J. Beighel
+	Date:	2021-02-02
+*/
+
+/*****	Includes	*****/
+	#include "APA102Driver.h"
+
+/*****	Defines		*****/
+
+
+/*****	Definitions	*****/
+
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	#define APA102PositionRedByte(eOrder, nRed)		((nRed & APA102_ColorMask) << ((eOrder & APA102_ROrderMask) >> APA102_ROrderShift))
+	
+	#define APA102PositionBlueByte(eOrder, nBlue)		((nBlue & APA102_ColorMask) << ((eOrder & APA102_BOrderMask) >> APA102_BOrderShift))
+	
+	#define APA102PositionGreenByte(eOrder, nGreen)	((nGreen & APA102_ColorMask) << ((eOrder & APA102_GOrderMask) >> APA102_GOrderShift))
+
+/*****	Functions	*****/
+eAPA102Return_t APA102Initialize(sAPA102Info_t *pDev, sSPIIface_t *pSpiDev) {
+	pDev->pSpi = pSpiDev;
+	
+	pDev->eOrder = APA102_RBGOrder;
+	pDev->nLightNum = 6;
+	memset(pDev->anLights, 0, sizeof(uint32_t) * pDev->nLightNum);
+	
+	return Success;
+}
+
+eAPA102Return_t APA102SetLightColor(sAPA102Info_t *pDev, uint32_t nLightID, uint8_t nRed, uint8_t nGreen, uint8_t nBlue) {
+	uint32_t nLightVal = 0;
+	
+	nLightVal |= APA102PositionRedByte(pDev->eOrder, nRed);
+	nLightVal |= APA102PositionGreenByte(pDev->eOrder, nGreen);
+	nLightVal |= APA102PositionBlueByte(pDev->eOrder, nBlue);
+	
+	pDev->anLights[nLightID] = nLightVal;
+	
+	return Success;
+}
+
+eAPA102Return_t APA102UpdateLights(sAPA102Info_t *pDev) {
+	uint32_t nLightCtr;
+	uint8_t nByte, nDump;
+	
+	pDev->pSpi->pfBeginTransfer(pDev->pSpi);
+	
+	//Start frame
+	nByte = 0x00;
+	for (nLightCtr = 0; nLightCtr < 4; nLightCtr++) {
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+	}
+	
+	//Write the 3 byte color code for each light
+	for (nLightCtr = 0; nLightCtr < pDev->nLightNum; nLightCtr++) {
+		nByte = 0xFF; //Global brightness, fully on
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		
+		//Write lowest byte
+		nByte = pDev->anLights[nLightCtr] & 0xFF;
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		
+		//Write middle byte
+		nByte = (pDev->anLights[nLightCtr] >> 8) & 0xFF;
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		
+		//Write highest byte
+		nByte = (pDev->anLights[nLightCtr] >> 16) & 0xFF;
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+	}
+	
+	//End Frame
+	nByte = 0xFF;
+	for (nLightCtr = 0; nLightCtr < (pDev->nLightNum + 15) / 16; nLightCtr++) {
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+		pDev->pSpi->pfTransferByte(pDev->pSpi, nByte, &nDump);
+	}
+	
+	pDev->pSpi->pfEndTransfer(pDev->pSpi);
+	
+	return Success;
+}

--- a/Projects/APA102led/APA102Driver.c
+++ b/Projects/APA102led/APA102Driver.c
@@ -30,7 +30,7 @@ eAPA102Return_t APA102Initialize(sAPA102Info_t *pDev, sSPIIface_t *pSpiDev) {
 	pDev->pSpi = pSpiDev;
 	
 	pDev->eOrder = APA102_RBGOrder;
-	pDev->nLightNum = 6;
+	pDev->nLightNum = 11;
 	memset(pDev->anLights, 0, sizeof(uint32_t) * pDev->nLightNum);
 	
 	return Success;

--- a/Projects/APA102led/APA102Driver.h
+++ b/Projects/APA102led/APA102Driver.h
@@ -1,0 +1,67 @@
+/**	@defgroup	GROUPNAME
+	@brief		
+	@details	v
+	#Description
+	
+	#File Information
+		File:	APA102Driver.h
+		Author:	J. Beighel
+		Date:	2021-02-02
+*/
+
+#ifndef __APA102Driver_H
+	#define __APA102Driver_H
+
+/*****	Includes	*****/
+	#include <string.h>
+
+	#include "CommonUtils.h"
+	#include "SPIGeneralInterface.h"
+
+/*****	Defines		*****/
+	
+	
+/*****	Definitions	*****/
+	typedef eReturn_t	eAPA102Return_t;
+	
+	typedef enum eAPA102Light_t {
+		APA102_ROrderMask		= 0x00FF0000,
+		APA102_ROrderShift		= 16,
+		APA102_GOrderMask		= 0x0000FF00,
+		APA102_GOrderShift		= 8,
+		APA102_BOrderMask		= 0x000000FF,	/**< Mask of order to get Blue bytes */
+		APA102_BOrderShift		= 0,			/**< Number of LShifts to get Blue order */
+		
+		APA102_BRGOrder			= 0x00000810,	/**< Bit shifts to position bytes in BRG order */
+		APA102_RBGOrder			= 0x00100800,	/**< Bit shifts to position bytes in RBG order */
+		
+		APA102_ColorMask		= 0xFF,
+		
+		APA102_NumBits			= 24,			/**< Number of bits to send for each LED */
+	} eAPA102Light_t;
+	
+	typedef struct sAPA102Info_t {
+		sSPIIface_t *pSpi;		/**< Pointer to SPI interface */
+		eAPA102Light_t eOrder;		/**< Light order to use for this set */
+		uint32_t nLightNum;			/**< Number of lights being controlled */
+		uint32_t anLights[64];		/**< Array of light colors to write */
+	} sAPA102Info_t;
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	eAPA102Return_t APA102Initialize(sAPA102Info_t *pDev, sSPIIface_t *pSpiDev);
+	
+	eAPA102Return_t APA102SetLightColor(sAPA102Info_t *pDev, uint32_t nLightID, uint8_t nRed, uint8_t nGreen, uint8_t nBlue);
+	
+	eAPA102Return_t APA102UpdateLights(sAPA102Info_t *pDev);
+
+/*****	Functions	*****/
+
+
+#endif
+

--- a/Projects/APA102led/CommonUtils.c
+++ b/Projects/APA102led/CommonUtils.c
@@ -1,0 +1,142 @@
+/*
+	File:	CommonUtils.h
+	Author:	J. Beighel
+	Date:	2021-01-26
+*/
+
+/***** Includes		*****/
+	#include "CommonUtils.h"
+
+
+/***** Constants	*****/
+
+
+/***** Definitions	*****/
+
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+
+
+/***** Functions	*****/
+bool NumberInArray_u8(uint8_t nNumber, const uint8_t *aList, uint32_t nListCnt) {
+	uint32_t nCtr;
+
+	for (nCtr = 0; nCtr < nListCnt; nCtr++) {
+		if (nNumber == aList[nCtr]) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool NumberInArray_u16(uint16_t nNumber, const uint16_t *aList, uint32_t nListCnt) {
+	uint32_t nCtr;
+
+	for (nCtr = 0; nCtr < nListCnt; nCtr++) {
+		if (nNumber == aList[nCtr]) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+uint32_t IndexInArray_u8(uint8_t nNumber, const uint8_t *aList, uint32_t nListCnt) {
+	uint32_t nCtr;
+
+	for (nCtr = 0; nCtr < nListCnt; nCtr++) {
+		if (nNumber == aList[nCtr]) {
+			return nCtr;
+		}
+	}
+
+	return nListCnt;
+}
+
+uint32_t IndexInArray_u16(uint16_t nNumber, const uint16_t *aList, uint32_t nListCnt) {
+	uint32_t nCtr;
+
+	for (nCtr = 0; nCtr < nListCnt; nCtr++) {
+		if (nNumber == aList[nCtr]) {
+			return nCtr;
+		}
+	}
+
+	return nListCnt;
+}
+
+uint8_t ContinueCalcCRC8(uint8_t nPolynomial, uint8_t nByte, uint8_t nPrevCRC) {
+	uint16_t nBitCtr;
+	uint8_t nBit;
+	uint8_t nTemp;
+
+	for (nBitCtr = 0; nBitCtr < 8; nBitCtr++) {
+		nBit = nByte & 0x80; //Get the highest bit
+
+		nTemp = nPrevCRC & 0x80;
+		if (nBit != 0) {
+			nTemp ^= 0x80;
+		}
+
+		nPrevCRC <<= 1;
+
+		if (nTemp != 0) {
+			nPrevCRC ^= nPolynomial;
+		}
+
+		nByte <<= 1;
+	}
+
+	return nPrevCRC;
+}
+
+uint8_t CalculateCRC8(uint8_t nPolynomial, uint8_t nInit, uint8_t nXOROut, const uint8_t *pData, uint32_t nDataLen) {
+	uint8_t nCrc;
+	uint32_t nCtr;
+
+	nCrc = nInit;
+
+	for (nCtr = 0; nCtr < nDataLen; nCtr++) {
+		nCrc = ContinueCalcCRC8(nPolynomial, pData[nCtr], nCrc);
+	}
+
+	nCrc ^= nXOROut;
+
+	return nCrc;
+}
+
+uint32_t CountSetBitsInInt32(uint32_t nVal) {
+	//SWAR algorithm
+	nVal = nVal - ((nVal >> 1) & 0x55555555); //Break into 1 counts of 2 bit chunks
+	nVal = (nVal & 0x33333333) + ((nVal >> 2) & 0x33333333); //Increase to 1 counts of 4 bit chunks
+	nVal = (nVal + (nVal >> 4)) & 0x0F0F0F0F; //Increase to 1 counts of 8 bit chunks
+	nVal = (nVal * 0x01010101) >> 24; //Sum all chunks into the highest byte, then shift down to lowest
+
+	return nVal;
+}
+
+uint16_t CountSetBitsInInt16(uint32_t nVal) {
+	//SWAR algorithm
+	nVal = nVal - ((nVal >> 1) & 0x5555); //Break into 1 counts of 2 bit chunks
+	nVal = (nVal & 0x3333) + ((nVal >> 2) & 0x3333); //Increase to 1 counts of 4 bit chunks
+	nVal = (nVal + (nVal >> 4)) & 0x0F0F; //Increase to 1 counts of 8 bit chunks
+	nVal = (nVal * 0x0101) >> 8; //Sum all chunks into the highest byte, then shift down to lowest
+
+	return nVal;
+}
+
+uint8_t ReverseBitsInUInt8(uint8_t nVal) {
+	uint8_t nCtr = 0, nRev = 0;
+	
+	for (nCtr = 0; nCtr < 8; nCtr++) {
+		nRev <<= 1;
+		nRev |= nVal & 0x01;
+		nVal >>= 1;
+	}
+	
+	return nRev;
+}

--- a/Projects/APA102led/CommonUtils.h
+++ b/Projects/APA102led/CommonUtils.h
@@ -1,0 +1,204 @@
+/**	@defgroup	commonutils
+	@brief		Common utilities and objects
+	@details	v 0.8
+	# Description #
+		This is a collection of commonly used utilities.
+		This includes variable types, macros, and constants.
+		
+	# Usage #
+		
+	# File Info #
+		File:	CommonUtils.h
+		Author:	J. Beighel
+		Date:	2021-01-26
+*/
+
+#ifndef __COMMONUTILS
+	#define __COMMONUTILS
+
+/***** Includes		*****/
+	#include <stdint.h>
+	#include <stdbool.h>
+	
+/***** Constants	*****/
+	/**	The maximum integer value that will fit in a uint8_t data type
+		@ingroup	commonutils
+	*/
+	#define UINT8_MAXVALUE	255
+	
+	/**	The maximum integer value that will fit in a uint16_t data type
+		@ingroup	commonutils
+	*/
+	#define UINT16_MAXVALUE	0xFFFF
+	
+	/**	The maximum integer value that will fit in a uint32_t data type
+		@ingroup	commonutils
+	*/
+	#define UINT32_MAXVALUE	0xFFFFFFFF
+
+/***** Definitions	*****/
+	typedef enum eReturn_t {
+		Warn_Unknown	= 1,	/**< An unknown but recoverable error happened during the operation */
+		Success			= 0,	/**< The operation completed successfully */
+		Fail_Unknown	= -1,	/**< An unknown and unrecoverable error happened during the operation */
+		Fail_NotImplem	= -2,	/**< Function not implemented */
+		Fail_CommError	= -3,	/**< Communications layer failure */
+		Fail_Invalid	= -4,	/**< Some value provided was invalid for this operaion */
+	} eReturn_t;
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+	/**	@brief		Check if all bits set in Mask, are set in Register
+		@param		Register	The value to test
+		@param		Mask		The bits to check in the Register
+		@return		Will return true if all bits that are 1 in Mask are also 1 in Register.
+			If any 1 bits in Mask are 0 in Register will return false.
+		@ingroup	commonutils
+	*/
+	#define CheckAllBitsInMask(Register, Mask)	((((Register) & (Mask)) == (Mask)) ? true : false)
+
+	/**	@brief		Check if any bits set in Mask, are set in Register
+		@param		Register	The value to test
+		@param		Mask		The bits to check in the Register
+		@return		Will return true if any bits that are 1 in Mask 1 in Register.  If no 
+			1 bits in Mask are 1 in Register will return false.
+		@ingroup	commonutils
+	*/
+	#define CheckAnyBitsInMask(Register, Mask)	((((Register) & (Mask)) != 0) ? true : false)
+
+	/**	@brief		Gives the value from Register with the bits set in mask cleared/zeroed
+		@details	The Register value will be updated by calling this macro, its return
+			is given for convenience.  The values supplied can not 
+			exceed 32 bits.
+
+			The word Zero was used in the name instead of Clear for visual clarity
+			from the various Check macros.
+		@param		Register	The value to be updated, having specified bits cleared
+		@param		Mask		The bits to clear in Register
+		@return		The value of Register after it is updated
+		@ingroup	commonutils
+	*/
+	#ifdef __cplusplus
+		#define ZeroAllBitsInMask(Register, Mask)	Register = ((typeof(Register))(((uint32_t)Register) & (~(uint32_t)(Mask))))
+	#else
+		#define ZeroAllBitsInMask(Register, Mask)	Register = (((uint32_t)Register) & (~(uint32_t)(Mask)))
+	#endif
+
+	/**	@brief		Gives the value from Register with the bits set in mask set to 1
+		@details	The Register value will not be updated by calling this macro, its 
+			return must be stored to retain this value.  The values supplied can not 
+			exceed 32 bits.
+		@param		Register	The value to be updated, having specified bits set
+		@param		Mask		The bits to set in Register
+		@return		The value of Register after it is updated
+		@ingroup	commonutils
+	*/
+	#ifdef __cplusplus
+		#define SetAllBitsInMask(Register, Mask)	Register = ((typeof(Register))(((uint32_t)Register) | ((uint32_t)(Mask))))
+	#else
+		#define SetAllBitsInMask(Register, Mask)	Register = (((uint32_t)Register) | ((uint32_t)(Mask)))
+	#endif
+
+	/**	@brief		Returns the larger of two numeric values
+		@param		nNum1	The first number to compare
+		@param		nNum2	The second number to compare
+		@return		The larger of the two values being compared
+		@ingroup	commonutils
+	*/
+	#define GetLargerNum(nNum1, nNum2)		((nNum1 > nNum2) ? nNum1 : nNum2)
+
+	/**	@brief		Returns the smaller of two numeric values
+		@param		nNum1	The first number to compare
+		@param		nNum2	The second number to compare
+		@return		The smaller of the two values being compared
+		@ingroup	commonutils
+	*/
+	#define GetSmallerNum(nNum1, nNum2)		((nNum1 < nNum2) ? nNum1 : nNum2)
+	
+	/**	@brief		Checks if a number is within a specified range
+		@details	Tests if the number is within the bounds of the number range specified.  If the number
+			matches the bounds it is considered within the range.
+		@param		nNumber		The number to test
+		@param		nRangeMin	The minimum bound of the range
+		@param		nRangeMax	The maximum bound of the range
+		@return		True if the number is within the range, false otherwise
+		@ingroup	commonutils
+	*/
+	#define	IsNumberInInclusiveRange(nNumber, nRangeMin, nRangeMax)		(((nNumber >= nRangeMin) && (nNumber <= nRangeMax)) ? true : false)
+	
+	/**	@brief		Determines if a given number exists in an array
+		@param		nNumber		The number to check for in the array
+		@param		aList		The array to searrch through
+		@param		nListCnt	The number of elements in the array
+		@return		True if the number is found in the array, false if it is not
+		@ingroup	commonutils
+	*/
+	bool NumberInArray_u8(uint8_t nNumber, const uint8_t *aList, uint32_t nListCnt);
+	
+	/**	@brief		Determines if a given number exists in an array
+		@param		nNumber		The number to check for in the array
+		@param		aList		The array to searrch through
+		@param		nListCnt	The number of elements in the array
+		@return		True if the number is found in the array, false if it is not
+		@ingroup	commonutils
+	*/
+	bool NumberInArray_u16(uint16_t nNumber, const uint16_t *aList, uint32_t nListCnt);
+
+	/**	@brief		Determines the index of a given number in an array
+		@param		nNumber		The number to check for in the array
+		@param		aList		The array to search through
+		@param		nListCnt	The number of elements in the array
+		@return		The index if the number is found in the array, nListCnt if it is not
+		@ingroup	commonutils
+	*/
+	uint32_t IndexInArray_u8(uint8_t nNumber, const uint8_t *aList, uint32_t nListCnt);
+	
+	/**	@brief		Determines the index of a given number in an array
+		@param		nNumber		The number to check for in the array
+		@param		aList		The array to search through
+		@param		nListCnt	The number of elements in the array
+		@return		The index if the number is found in the array, nListCnt if it is not
+		@ingroup	commonutils
+	*/
+	uint32_t IndexInArray_u16(uint16_t nNumber, const uint16_t *aList, uint32_t nListCnt);
+
+	/**	@brief		Calculates an 8 bit CRC value for an array of data
+		@param		nPolynomial		The 8 bit polynomial to use while generating the CRC
+		@param		nInit			The starting value to use when generating the CRC
+		@param		nXOROut			Exclusive or the output with this value, set to 0x00 for no XOR
+		@param		pData			Pointer to the data to CRC
+		@param		nDataLen		The number of bytes in the data
+		@ingroup	commonutils
+	*/
+	uint8_t CalculateCRC8(uint8_t nPolynomial, uint8_t nInit, uint8_t nXOROut, const uint8_t *pData, uint32_t nDataLen);
+	
+	/**	@brief		Counts the 1 bits in an integer value
+		@param		nVal		The value to count the set bits in
+		@return		Count of the 1 bits in the value
+		@ingroup	commonutils
+	*/
+	uint32_t CountSetBitsInInt32(uint32_t nVal);
+	
+	/**	@brief		Counts the 1 bits in an integer value
+		@param		nVal		The value to count the set bits in
+		@return		Count of the 1 bits in the value
+		@ingroup	commonutils
+	*/
+	uint16_t CountSetBitsInInt16(uint32_t nVal);
+	
+	/**	@brief		Returns the parameter value with the bits reversed
+		@details	If the value 0xC5 (0b11000101) is passed in then the 
+			returned value will be 0xA3 (0b10100011)
+		@param		nVal		Value to reverse the bits in
+		@return		Bit reversed value
+		@ingroup	commonutils
+	*/
+	uint8_t ReverseBitsInUInt8(uint8_t nVal);
+
+/***** Functions	*****/
+
+
+#endif
+

--- a/Projects/APA102led/RasPiBase.c
+++ b/Projects/APA102led/RasPiBase.c
@@ -1,0 +1,66 @@
+/**	File:	RasPiBase.c
+	Author:	J. Beighel
+	Date:	12-17-2020
+*/
+
+/*****	Includes	*****/
+	//Genereral use libraries
+	#include "CommonUtils.h"
+	#include "SPIGeneralInterface.h"
+	
+	#include "SPI_RaspberryPi.h"
+	
+	//Driver libraries
+	#include "APA102Driver.h"
+	
+/*****	Defines		*****/
+
+
+/*****	Definitions	*****/
+
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+	sSPIIface_t gSPI;
+	
+	sAPA102Info_t gLed;
+	
+/*****	Prototypes 	*****/
+
+
+/*****	Functions	*****/
+eReturn_t BoardInit(void) {
+	int eResult;
+	
+	//Init processor (pin support work)
+	eResult = SPI_INIT(&gSPI, SPI_1_HWINFO, 5000000, SPI_MSBFirst, SPI_Mode0);
+	if (eResult != SPI_Success) {
+		return Fail_Unknown;
+	}
+	
+	//Init peripherals (board support work)
+	APA102Initialize(&gLed, &gSPI);
+	
+	return Success;
+}
+
+int main(int nArgCnt, char **aArgVals) {
+	
+	if (BoardInit() != Success) {
+		printf("Board initialization failed.\r\n");
+		return 1;
+	}
+	
+	APA102SetLightColor(&gLed, 0, 150, 150, 150);
+	APA102SetLightColor(&gLed, 1, 0, 0, 150);
+	APA102SetLightColor(&gLed, 2, 0, 150, 0);
+	APA102SetLightColor(&gLed, 3, 150, 0, 0);
+	APA102SetLightColor(&gLed, 4, 150, 150, 0);
+	APA102SetLightColor(&gLed, 5, 150, 0, 150);
+	APA102SetLightColor(&gLed, 6, 0, 150, 150);
+	APA102UpdateLights(&gLed);
+	
+	return 0;
+}

--- a/Projects/APA102led/RasPiBase.c
+++ b/Projects/APA102led/RasPiBase.c
@@ -20,7 +20,32 @@
 
 
 /*****	Constants	*****/
-
+const uint32_t anPattern[] = {
+	0x00220000,
+	0x00220000,
+	0x00221100,
+	0x00221100,
+	0x00222200,
+	0x00222200,
+	0x00112200,
+	0x00112200,
+	0x00002200,
+	0x00002200,
+	0x00002211,
+	0x00002211,
+	0x00002222,
+	0x00002222,
+	0x00001122,
+	0x00001122,
+	0x00000022,
+	0x00000022,
+	0x00110022,
+	0x00110022,
+	0x00220022,
+	0x00220022,
+	0x00220011,
+	0x00220011,
+};
 
 /*****	Globals		*****/
 	sSPIIface_t gSPI;
@@ -53,13 +78,17 @@ int main(int nArgCnt, char **aArgVals) {
 		return 1;
 	}
 	
-	APA102SetLightColor(&gLed, 0, 150, 150, 150);
-	APA102SetLightColor(&gLed, 1, 0, 0, 150);
-	APA102SetLightColor(&gLed, 2, 0, 150, 0);
-	APA102SetLightColor(&gLed, 3, 150, 0, 0);
-	APA102SetLightColor(&gLed, 4, 150, 150, 0);
-	APA102SetLightColor(&gLed, 5, 150, 0, 150);
-	APA102SetLightColor(&gLed, 6, 0, 150, 150);
+	APA102SetLightColor(&gLed, 0, 30, 30, 30);
+	APA102SetLightColor(&gLed, 1, 0, 0, 30);
+	APA102SetLightColor(&gLed, 2, 0, 15, 30);
+	APA102SetLightColor(&gLed, 3, 0, 30, 30);
+	APA102SetLightColor(&gLed, 4, 0, 30, 15);
+	APA102SetLightColor(&gLed, 5, 0, 30, 0);
+	APA102SetLightColor(&gLed, 6, 15, 30, 0);
+	APA102SetLightColor(&gLed, 7, 30, 30, 0);
+	APA102SetLightColor(&gLed, 8, 30, 15, 0);
+	APA102SetLightColor(&gLed, 9, 30, 0, 0);
+	APA102SetLightColor(&gLed, 10, 30, 0, 15);
 	APA102UpdateLights(&gLed);
 	
 	return 0;

--- a/Projects/APA102led/SPIGeneralInterface.c
+++ b/Projects/APA102led/SPIGeneralInterface.c
@@ -1,0 +1,63 @@
+/*
+		File:	SPIGeneralInterface.c
+		Author:	J. Beighel
+		Created:09-04-2020
+*/
+
+/***** Includes		*****/
+	#include "SPIGeneralInterface.h"
+
+/***** Definitions	*****/
+	
+
+/***** Constants	*****/
+
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+
+
+/***** Functions	*****/
+eSPIReturn_t SPIInterfaceInitialize(sSPIIface_t *pIface) {
+	pIface->pfInitialise = &SPIPortInitialize;
+	pIface->pfBeginTransfer = &SPIBeginTransfer;
+	pIface->pfEndTransfer = &SPIEndTransfer;
+	pIface->pfTransferByte = &SPITransferByte;
+	pIface->pfTransfer2Bytes = &SPITransfer2Bytes;
+	pIface->pfGetCapabilities = &SPIGetCapabilities;
+
+	pIface->nBusClockFreq = 5000000;
+	pIface->pHWInfo = NULL;
+	pIface->eMode = SPI_Mode0;
+	pIface->eDataOrder = SPI_MSBFirst;
+	
+	return SPI_Success;
+}
+
+eSPIReturn_t SPIPortInitialize(sSPIIface_t *pIface, void *pHWInfo, uint32_t nBusClockFreq, eSPIDataOrder_t eDataOrder, eSPIMode_t eMode) {
+	return SPIFail_Unsupported;
+}
+
+eSPIReturn_t SPIBeginTransfer(sSPIIface_t *pIface) {
+	return SPIFail_Unsupported;
+}
+
+eSPIReturn_t SPIEndTransfer(sSPIIface_t *pIface) {
+	return SPIFail_Unsupported;
+}
+	
+eSPIReturn_t SPITransferByte(sSPIIface_t *pIface, uint8_t nSendByte, uint8_t *pnReadByte) {
+	return SPIFail_Unsupported;
+}
+
+eSPIReturn_t SPITransfer2Bytes(sSPIIface_t *pIface, const uint8_t *anSendBytes, uint8_t *anReadBytes) {
+	return SPIFail_Unsupported;
+}
+
+eSPICapabilities_t SPIGetCapabilities(sSPIIface_t *pIface) {
+	return SPI_NoCapabilities;
+}
+
+

--- a/Projects/APA102led/SPIGeneralInterface.h
+++ b/Projects/APA102led/SPIGeneralInterface.h
@@ -1,0 +1,151 @@
+/**	@defgroup	spiiface
+	@brief		General interface for using the SPI bus
+	@details	v0.3
+	# Intent #
+		This module is to create a common interface for interacting with a SPI bus.  Drivers 
+		for devices that operate over this bus should use this interface to operate the 
+		peripheral bus.  This is to ensure that the driver will not be bound to a specific 
+		processor or platform since this interface can be implemented anywhere.
+		
+		The interface itself will provide no functionality, it only offers a standardized set
+		of functions to use to communicate with the hardware.  Device drivers can rely on these
+		to get consistent capabilities and behavior from the bus.  Processor bus drivers are
+		expected to implement and provide these functions.
+		
+	# Usage #
+		Each processor or device bus that will support this interface must create define and
+		create its own copies of the interface functions.
+
+		The SPIPortInitialize() function in the driver must call the SPIInterfaceInitialize()
+		function to prepare the instance of the sSPIIface_t object.  This will ensure that all
+		function pointers will have a valid value, applications can not inadvertently branch to
+		an nonexistent function.  It will then overwrite the contents of the object with its
+		information.
+		
+		The driver must also define values for each hardware object that it covers.  This should
+		take the form of SPI_#_HWINFO
+
+		In addition the driver must define a value to reach the SPIPortInitialize() function.
+		This should take the form of SPI_INIT
+
+		Having these defined gives a very consistent and generic means of establishing the
+		interface object in the application that looks like this:
+
+		sSPIIface_t SpiObj;
+
+		SPI_INIT(&SpiObj, SPI_1_HWINFO, 5000000, SPI_MSBFirst, SPI_Mode0);
+
+		The last thing the driver must do is create a define of the capabilities that it allows.
+		This define should be options from the eSPICapabilities_t enumeration ORed together.  The
+		peripheral drivers will similarly provide a define a value listing the capabilities that
+		it requires.  Using these defines the application should be able to determine at
+		compilation whether or not a peripheral will work on a particular bus.  This define
+		should take the form of SPI_#_CAPS
+
+	# File Information #
+		File:	SPIGeneralInterface.c
+		Author:	J. Beighel
+		Date:	2021-01-26
+*/
+
+#ifndef __SPIGENIFACE
+	#define __SPIGENIFACE
+
+/***** Includes		*****/
+	#include <stddef.h>
+	#include <stdint.h>
+
+/***** Definitions	*****/
+	typedef struct sSPIIface_t sSPIIface_t;  //Declaring this early, will define it later
+
+	/**	@brief		Enumeration of all SPI bus capabilities
+		@ingroup	spiiface
+	*/
+	typedef enum eSPICapabilities_t {
+		SPI_NoCapabilities	= 0x00000000,	/**< Default, SPI bus driver has no capabilities */
+		SPI_Configure		= 0x00000001,	/**< SPI bus driver allows configuration of the port */
+		SPI_BeginTransfer	= 0x00000002,	/**< SPI bus driver allows user to begin a data transfer */
+		SPI_EndTransfer		= 0x00000004,	/**< SPI bus driver allows user to end a data transfer */
+		SPI_BiDir1Byte		= 0x00000008,	/**< SPI bus driver allows user to bi-directionally transfer 1 byte */
+		SPI_BiDir2Bytes		= 0x00000010,	/**< SPI bus driver allows user to bi-directionally transfer 2 bytes */
+	} eSPICapabilities_t;
+
+	/**	@brief		Enumeration of markers to indicate the order the bus sends data out 
+		@ingroup	spiiface
+	*/
+	typedef enum eSPIDataOrder_t {
+		SPI_MSBFirst,
+		SPI_LSBFirst,
+	} eSPIDataOrder_t;
+	
+	/**	@brief		Enumeration of clock and data sampling methods the bus will use
+		@details	CPOL is clock polarity, 0 means it begins in a low state and the 
+			first edge will be rising.  One means it begins in a high state and the 
+			first edge will be falling.
+			
+			CPHA is clock phase and spicifies when the data bits will change (output)
+			and when they will be read (input / data capture).
+		@ingroup	spiiface
+	*/
+	typedef enum eSPIMode_t {
+		SPI_Mode0,			/**< CPOL 0, CPHA 0, Output Edge Falling, Data Capture Edge Rising */
+		SPI_Mode1,			/**< CPOL 0, CPHA 1, Output Edge Rising, Data Capture Edge Falling */
+		SPI_Mode2,			/**< CPOL 1, CPHA 0, Output Edge Rising, Data Capture Edge Falling */
+		SPI_Mode3,			/**< CPOL 1, CPHA 1, Output Edge Falling, Data Capture Edge Rising */
+	} eSPIMode_t;
+
+	/**	@brief		Enumeration of all SPI interface return values
+		@ingroup	spiiface
+	*/
+	typedef enum eSPIReturn_t {
+		SPIWarn_Unknown		= 1,	/**< An unknown but recoverable error happened during the operation */
+		SPI_Success			= 0,	/**< The operation completed successfully */
+		SPIFail_Unknown		= -1,	/**< An unknown and unrecoverable error happened during the operation */
+		SPIFail_Unsupported	= -2,	/**< The requested operation is not supported by this device */
+		SPIFail_Timeout		= -3,	/**< The requested operation timed out before completion */
+	} eSPIReturn_t;
+	
+	typedef eSPIReturn_t (*pfInitializeSPIBus_t)(sSPIIface_t *pIface, void *pHWInfo, uint32_t nBusClockFreq, eSPIDataOrder_t eDataOrder, eSPIMode_t eMode);
+	
+	typedef struct sSPIIface_t {
+		pfInitializeSPIBus_t pfInitialise;
+		eSPIReturn_t (*pfBeginTransfer)(sSPIIface_t *pIface);
+		eSPIReturn_t (*pfEndTransfer)(sSPIIface_t *pIface);
+		
+		eSPIReturn_t (*pfTransferByte)(sSPIIface_t *pIface, uint8_t nSendByte, uint8_t *pnReadByte);
+		eSPIReturn_t (*pfTransfer2Bytes)(sSPIIface_t *pIface, const uint8_t *anSendBytes, uint8_t *anReadBytes);
+		
+		eSPICapabilities_t (*pfGetCapabilities)(sSPIIface_t *pIface);
+
+		uint32_t		nBusClockFreq;
+		eSPIDataOrder_t	eDataOrder;
+		eSPIMode_t		eMode;
+		void			*pHWInfo;
+	} sSPIIface_t;
+	
+
+/***** Constants	*****/
+
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+	eSPIReturn_t SPIInterfaceInitialize(sSPIIface_t *pIface);
+	
+	eSPIReturn_t SPIPortInitialize(sSPIIface_t *pIface, void *pHWInfo, uint32_t nBusClockFreq, eSPIDataOrder_t eDataOrder, eSPIMode_t eMode);
+
+	eSPIReturn_t SPIBeginTransfer(sSPIIface_t *pIface);
+	
+	eSPIReturn_t SPIEndTransfer(sSPIIface_t *pIface);
+		
+	eSPIReturn_t SPITransferByte(sSPIIface_t *pIface, uint8_t nSendByte, uint8_t *pnReadByte);
+
+	eSPIReturn_t SPITransfer2Bytes(sSPIIface_t *pIface, const uint8_t *anSendBytes, uint8_t *anReadBytes);
+
+	eSPICapabilities_t SPIGetCapabilities(sSPIIface_t *pIface);
+
+/***** Functions	*****/
+
+#endif
+

--- a/Projects/APA102led/SPI_RaspberryPi.c
+++ b/Projects/APA102led/SPI_RaspberryPi.c
@@ -1,0 +1,186 @@
+/**	File:	SPI_RaspberryPi.c
+	Author:	J. Beighel
+	Date:	12-01-2020
+*/
+
+/*****	Includes	*****/
+	#include "SPI_RaspberryPi.h"
+
+/*****	Defines		*****/
+
+
+/*****	Definitions	*****/
+
+
+/*****	Constants	*****/
+	/**	@brief		Path and file name of the filesystem object for the SPI 1 bus
+		@ingroup	spiraspberrypi
+	*/
+	const char cgSPI1File[] = "/dev/spidev0.0";
+	
+	/**	@brief		Path and file name of the filesystem object for the SPI 2 bus
+		@details	This SPI bus is only available on the 40 pin header
+		@ingroup	spiraspberrypi
+	*/
+	const char cgSPI2File[] = "/dev/spidev0.1";
+
+	/**	@brief		Array of all SPI buses for the Raspberry Pi
+		@ingroup	spiraspberrypi
+	*/
+	sRasPiSPIHWInfo_t gSPIHWInfo [] = {
+		{ .pcFilePath = cgSPI1File, .SPIFile = -1, },
+		{ .pcFilePath = cgSPI2File, .SPIFile = -1, },
+	};
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	eSPIReturn_t RasPiSPIBeginTransfer(sSPIIface_t *pIface);
+	
+	eSPIReturn_t RasPiSPIEndTransfer(sSPIIface_t *pIface);
+	
+	eSPIReturn_t RasPiSPITransferByte(sSPIIface_t *pIface, uint8_t nSendByte, uint8_t *pnReadByte);
+
+/*****	Functions	*****/
+
+eSPIReturn_t RasPiSPIPortInitialize(sSPIIface_t *pIface, void *pHWInfo, uint32_t nBusClockFreq, eSPIDataOrder_t eDataOrder, eSPIMode_t eMode) {
+	sRasPiSPIHWInfo_t *pSPI = (sRasPiSPIHWInfo_t *)pHWInfo;
+	int32_t nResult;
+	uint32_t nSpiMode = 0;
+	uint8_t nBits = RASPISPI_BITSPERWORD;
+	eSPIReturn_t eRetVal = SPI_Success;
+	
+	//Setup the interface structure
+	SPIInterfaceInitialize(pIface);
+	
+	pIface->nBusClockFreq = nBusClockFreq;
+	pIface->eDataOrder = eDataOrder;
+	pIface->eMode = eMode;
+	pIface->pHWInfo = pHWInfo;
+	
+	//Se all the interface functions
+	pIface->pfInitialise = &RasPiSPIPortInitialize;
+	pIface->pfBeginTransfer = &RasPiSPIBeginTransfer;
+	pIface->pfEndTransfer = &RasPiSPIEndTransfer;
+	pIface->pfTransferByte = &RasPiSPITransferByte;
+	
+	//Set up the hardware
+	pSPI->SPIFile = open(pSPI->pcFilePath, O_RDWR);
+	
+	if (pSPI->SPIFile < 0) {
+		pSPI->nLastErr = errno;
+		return SPIFail_Unknown;
+	}
+	
+	//Determine the SPI mode settigns
+	//Unused flags: SPI_LOOP, SPI_CS_HIGH, SPI_TX_OCTAL, SPI_TX_QUAD, SPI_TX_DUAL
+	//              SPI_RX_OCTAL, SPI_RX_QUAD, SPI_RX_DUAL, SPI_3WIRE
+	nSpiMode = SPI_NO_CS;
+	
+	switch (eMode) {
+		case SPI_Mode0:
+			break;
+		case SPI_Mode1:
+			nSpiMode |= SPI_CPHA;
+			break;
+		case SPI_Mode2:
+			nSpiMode |= SPI_CPOL;
+			break;
+		case SPI_Mode3:
+			nSpiMode |= SPI_CPHA | SPI_CPOL;
+			break;
+		default :
+			return SPIFail_Unsupported;
+	}
+	
+	if (eDataOrder == SPI_LSBFirst) {
+		nSpiMode |= SPI_LSB_FIRST;
+	}
+	
+	//Apply the settints to read and write
+	nResult = ioctl(pSPI->SPIFile, SPI_IOC_WR_MODE32, &nSpiMode);
+	if (nResult == -1) {
+		pSPI->nLastErr = errno;
+		eRetVal = SPIFail_Unknown;
+	}
+	
+	nResult = ioctl(pSPI->SPIFile, SPI_IOC_RD_MODE32, &nSpiMode);
+	if (nResult == -1) {
+		pSPI->nLastErr = errno;
+		eRetVal = SPIFail_Unknown;
+	}
+	
+	//Read and write have the same word size
+	nResult = ioctl(pSPI->SPIFile, SPI_IOC_WR_BITS_PER_WORD, &nBits);
+	if (nResult == -1) {
+		pSPI->nLastErr = errno;
+		eRetVal = SPIFail_Unknown;
+	}
+
+	nResult = ioctl(pSPI->SPIFile, SPI_IOC_RD_BITS_PER_WORD, &nBits);
+	if (nResult == -1) {
+		pSPI->nLastErr = errno;
+		eRetVal = SPIFail_Unknown;
+	}
+	
+	//Set the clock frequency
+	nResult = ioctl(pSPI->SPIFile, SPI_IOC_WR_MAX_SPEED_HZ, &nBusClockFreq);
+	if (nResult == -1) {
+		pSPI->nLastErr = errno;
+		eRetVal = SPIFail_Unknown;
+	}
+
+	nResult = ioctl(pSPI->SPIFile, SPI_IOC_RD_MAX_SPEED_HZ, &nBusClockFreq);
+	if (nResult == -1) {
+		pSPI->nLastErr = errno;
+		eRetVal = SPIFail_Unknown;
+	}
+	
+	//If anything failed close the file
+	if (eRetVal != SPI_Success) {
+		close(pSPI->SPIFile);
+		pSPI->SPIFile = -1;
+	}
+	
+	return eRetVal;
+}
+
+eSPIReturn_t RasPiSPIBeginTransfer(sSPIIface_t *pIface) {
+	// No work to do here, just need to include the function
+	return SPI_Success;
+}
+	
+eSPIReturn_t RasPiSPIEndTransfer(sSPIIface_t *pIface) {
+	// No work to do here, just need to include the function
+	return SPI_Success;
+}
+
+eSPIReturn_t RasPiSPITransferByte(sSPIIface_t *pIface, uint8_t nSendByte, uint8_t *pnReadByte) {
+	sRasPiSPIHWInfo_t *pSPI = (sRasPiSPIHWInfo_t *)(pIface->pHWInfo);
+	struct spi_ioc_transfer TranInfo;
+	int32_t nResult;
+	
+	memset(&TranInfo, 0, sizeof(struct spi_ioc_transfer));
+	
+	TranInfo.tx_buf = (uint32_t)(&nSendByte);
+	TranInfo.rx_buf = (uint32_t)pnReadByte;
+	TranInfo.len = 1; //This function sends 1 byte
+	TranInfo.delay_usecs = 0; //Delay between CS and data transfer
+	//TranInfo.speed_hz = pIface->nBusClockFreq;
+	TranInfo.bits_per_word = RASPISPI_BITSPERWORD;
+
+	TranInfo.tx_nbits = 1; //1 data out line
+	TranInfo.rx_nbits = 1; //1 data in line
+	
+	//This is really only valid if multiple transfers are queued
+	//TranInfo.cs_change = true; //true deselcts the device before next transfer
+	//This call performs the data transfer using the provided buffers
+	nResult = ioctl(pSPI->SPIFile, SPI_IOC_MESSAGE(1), &TranInfo);
+	if (nResult <= 0) {
+		pSPI->nLastErr = errno;
+		return SPIFail_Unknown;
+	}
+	
+	return SPI_Success;
+}

--- a/Projects/APA102led/SPI_RaspberryPi.h
+++ b/Projects/APA102led/SPI_RaspberryPi.h
@@ -1,0 +1,72 @@
+/**	@defgroup	spiraspberrypi
+	@brief		SPI General Interface implementation for Raspberry Pi
+	@details	v0.2
+	#Description
+	
+	#File Information
+		File:	SPI_RaspberryPi.h
+		Author:	J. Beighel
+		Date:	2021-01-22
+*/
+
+#ifndef __SPIRASPBERRYPI_H
+	#define __SPIRASPBERRYPI_H
+
+/*****	Includes	*****/
+	#include <stdio.h>
+	#include <string.h>
+
+	#include <unistd.h>
+	#include <fcntl.h>
+	#include <errno.h>
+	#include <sys/ioctl.h>
+	#include <linux/spi/spidev.h>
+	
+	#include "CommonUtils.h"
+	#include "SPIGeneralInterface.h"
+
+/*****	Defines		*****/
+	/**	@brief		Function to call to initialize the first SPI bus
+		@ingroup	spiraspberrypi
+	*/
+	#define SPI_INIT			RasPiSPIPortInitialize
+	
+	/**	@brief		Hardware information for the first SPI bus
+		@ingroup	spiraspberrypi
+	*/
+	#define SPI_1_HWINFO		((void *)&(gSPIHWInfo[0]))
+	
+	/**	@brief		SPI 1 hardware object
+		@ingroup	spiraspberrypi
+	*/
+	#define SPI_1_CAPS			(SPI_Configure | SPI_BeginTransfer | SPI_EndTransfer | SPI_BiDir1Byte)
+	
+	/**	@brief		Number of bits included in each word of the SPI transfer
+		@ingroup	spiraspberrypi
+	*/
+	#define RASPISPI_BITSPERWORD	8
+
+/*****	Definitions	*****/
+	/**	@brief		Structure holding information on the SPI Hardware
+		@ingroup	i2craspberrypi
+	*/
+	typedef struct sRasPiSPIHWInfo_t {
+		const char *pcFilePath;	/**< Path to the filesystem object for this bus */
+		int32_t SPIFile;		/**< File handle to use when interacting with this bus */
+		int32_t nLastErr;		/**< Last error reported by the OS SPI function calls */
+	} sRasPiSPIHWInfo_t;
+
+/*****	Constants	*****/
+	extern sRasPiSPIHWInfo_t gSPIHWInfo[];
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	eSPIReturn_t RasPiSPIPortInitialize(sSPIIface_t *pIface, void *pHWInfo, uint32_t nBusClockFreq, eSPIDataOrder_t eDataOrder, eSPIMode_t eMode);
+
+/*****	Functions	*****/
+
+
+#endif
+

--- a/Projects/APA102led/makefile
+++ b/Projects/APA102led/makefile
@@ -1,0 +1,102 @@
+TARGET = RasPiBase.exe
+COMMONDEPS = CommonUtils.o SPIGeneralInterface.o
+LINUXDEPS = SPI_RaspberryPi.o
+DRIVERS = APA102Driver.o
+
+#CCARGS of gnu11 adds the posix defines needed for the time stuff
+
+#determine operating system to set environment
+ifndef OS
+	OS = $(shell uname -s)
+endif
+
+ifeq ($(OS),Windows_NT)
+	ENV = Windows/MinGW
+	CC = gcc
+	CPP = g++
+	DEL = del /Q
+	CCARGS += -std=c11 -lwsock32
+	CCDBG = -ggdb
+	CPPARGS += -std=c++11 -lwsock32
+	CPPDBG = -ggdb
+	DEPS = $(COMMONDEPS) $(WINDOWSDEPS) $(DRIVERS)
+endif
+
+ifeq ($(OS),Linux)
+	ENV = Linux
+	CC = gcc
+	CPP = g++
+	DEL = rm -f
+	CCARGS += -std=c11 
+	CCDBG = -ggdb
+	CPPARGS += -std=c++11
+	CPPDBG = -ggdb
+	DEPS = $(COMMONDEPS) $(LINUXDEPS) $(DRIVERS)
+endif
+
+#Targets that are not file dependents
+.PHONY: all clean debug drivers main dispenv
+
+#Target to build entire project
+main: dispenv $(DEPS) $(DRIVERS) $(TARGET)
+	@ echo "----------------------------------------------------------"
+	@ echo "Compiled All Components"
+	@ echo "Deps: $(DEPS)"
+	@ echo "Target: $(TARGET)"
+
+#Workspace handling targets
+all: clean main
+
+debug: 
+	@ echo "----------------------------------------------------------"
+	@ echo "Building with debug symbols: $(CCDBG) / $(CPPDBG)"
+	@ echo ""
+	$(eval CCARGS = $(CCDBG) $(CCARGS))
+	$(eval CPPARGS = $(CPPDBG) $(CPPARGS))
+
+dispenv: 
+	@ echo "----------------------------------------------------------"
+	@ echo "Using Environment: $(ENV)"
+	@ echo ""
+
+clean:
+	@ echo "----------------------------------------------------------"
+	@ echo "Cleaning Build Space"
+	$(DEL) $(TARGET)
+	$(DEL) $(DEPS)
+	$(DEL) $(DRIVERS)
+	@ echo ""
+
+drivers: 
+	@ echo "----------------------------------------------------------"
+	@ echo "Cleaning Peripheral Drivers"
+	$(DEL) $(DRIVERS)
+	$(DEL) $(TARGET)
+	@ echo ""
+	#Re-enter make with any custom parameters still set
+	make CCARGS="$(CCARGS)" CPPARGS="$(CPPARGS)" 
+
+#Dependency targets
+%.o: %.c
+	@ echo "----------------------------------------------------------"
+	@ echo "Compiling $@"
+	$(CC)  -c $^ $(CCARGS)
+	@ echo ""
+	
+%.o: %.cpp
+	@ echo "----------------------------------------------------------"
+	@ echo "Compiling $@"
+	$(CPP)  -c $^ $(CPPARGS)
+	@ echo ""
+
+%.exe: %.c
+	@ echo "----------------------------------------------------------"
+	@ echo "Compiling $@"
+	$(CC) $^ $(DEPS) $(CCARGS) -o $@
+	@ echo ""
+	
+%.exe: %.cpp
+	@ echo "----------------------------------------------------------"
+	@ echo "Compiling $@"
+	$(CPP) $^ $(DEPS) $(CPPARGS) -o $@
+	@ echo ""

--- a/Projects/WS2812Bled/CommonUtils.c
+++ b/Projects/WS2812Bled/CommonUtils.c
@@ -1,0 +1,142 @@
+/*
+	File:	CommonUtils.h
+	Author:	J. Beighel
+	Date:	2021-01-26
+*/
+
+/***** Includes		*****/
+	#include "CommonUtils.h"
+
+
+/***** Constants	*****/
+
+
+/***** Definitions	*****/
+
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+
+
+/***** Functions	*****/
+bool NumberInArray_u8(uint8_t nNumber, const uint8_t *aList, uint32_t nListCnt) {
+	uint32_t nCtr;
+
+	for (nCtr = 0; nCtr < nListCnt; nCtr++) {
+		if (nNumber == aList[nCtr]) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool NumberInArray_u16(uint16_t nNumber, const uint16_t *aList, uint32_t nListCnt) {
+	uint32_t nCtr;
+
+	for (nCtr = 0; nCtr < nListCnt; nCtr++) {
+		if (nNumber == aList[nCtr]) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+uint32_t IndexInArray_u8(uint8_t nNumber, const uint8_t *aList, uint32_t nListCnt) {
+	uint32_t nCtr;
+
+	for (nCtr = 0; nCtr < nListCnt; nCtr++) {
+		if (nNumber == aList[nCtr]) {
+			return nCtr;
+		}
+	}
+
+	return nListCnt;
+}
+
+uint32_t IndexInArray_u16(uint16_t nNumber, const uint16_t *aList, uint32_t nListCnt) {
+	uint32_t nCtr;
+
+	for (nCtr = 0; nCtr < nListCnt; nCtr++) {
+		if (nNumber == aList[nCtr]) {
+			return nCtr;
+		}
+	}
+
+	return nListCnt;
+}
+
+uint8_t ContinueCalcCRC8(uint8_t nPolynomial, uint8_t nByte, uint8_t nPrevCRC) {
+	uint16_t nBitCtr;
+	uint8_t nBit;
+	uint8_t nTemp;
+
+	for (nBitCtr = 0; nBitCtr < 8; nBitCtr++) {
+		nBit = nByte & 0x80; //Get the highest bit
+
+		nTemp = nPrevCRC & 0x80;
+		if (nBit != 0) {
+			nTemp ^= 0x80;
+		}
+
+		nPrevCRC <<= 1;
+
+		if (nTemp != 0) {
+			nPrevCRC ^= nPolynomial;
+		}
+
+		nByte <<= 1;
+	}
+
+	return nPrevCRC;
+}
+
+uint8_t CalculateCRC8(uint8_t nPolynomial, uint8_t nInit, uint8_t nXOROut, const uint8_t *pData, uint32_t nDataLen) {
+	uint8_t nCrc;
+	uint32_t nCtr;
+
+	nCrc = nInit;
+
+	for (nCtr = 0; nCtr < nDataLen; nCtr++) {
+		nCrc = ContinueCalcCRC8(nPolynomial, pData[nCtr], nCrc);
+	}
+
+	nCrc ^= nXOROut;
+
+	return nCrc;
+}
+
+uint32_t CountSetBitsInInt32(uint32_t nVal) {
+	//SWAR algorithm
+	nVal = nVal - ((nVal >> 1) & 0x55555555); //Break into 1 counts of 2 bit chunks
+	nVal = (nVal & 0x33333333) + ((nVal >> 2) & 0x33333333); //Increase to 1 counts of 4 bit chunks
+	nVal = (nVal + (nVal >> 4)) & 0x0F0F0F0F; //Increase to 1 counts of 8 bit chunks
+	nVal = (nVal * 0x01010101) >> 24; //Sum all chunks into the highest byte, then shift down to lowest
+
+	return nVal;
+}
+
+uint16_t CountSetBitsInInt16(uint32_t nVal) {
+	//SWAR algorithm
+	nVal = nVal - ((nVal >> 1) & 0x5555); //Break into 1 counts of 2 bit chunks
+	nVal = (nVal & 0x3333) + ((nVal >> 2) & 0x3333); //Increase to 1 counts of 4 bit chunks
+	nVal = (nVal + (nVal >> 4)) & 0x0F0F; //Increase to 1 counts of 8 bit chunks
+	nVal = (nVal * 0x0101) >> 8; //Sum all chunks into the highest byte, then shift down to lowest
+
+	return nVal;
+}
+
+uint8_t ReverseBitsInUInt8(uint8_t nVal) {
+	uint8_t nCtr = 0, nRev = 0;
+	
+	for (nCtr = 0; nCtr < 8; nCtr++) {
+		nRev <<= 1;
+		nRev |= nVal & 0x01;
+		nVal >>= 1;
+	}
+	
+	return nRev;
+}

--- a/Projects/WS2812Bled/CommonUtils.h
+++ b/Projects/WS2812Bled/CommonUtils.h
@@ -1,0 +1,204 @@
+/**	@defgroup	commonutils
+	@brief		Common utilities and objects
+	@details	v 0.8
+	# Description #
+		This is a collection of commonly used utilities.
+		This includes variable types, macros, and constants.
+		
+	# Usage #
+		
+	# File Info #
+		File:	CommonUtils.h
+		Author:	J. Beighel
+		Date:	2021-01-26
+*/
+
+#ifndef __COMMONUTILS
+	#define __COMMONUTILS
+
+/***** Includes		*****/
+	#include <stdint.h>
+	#include <stdbool.h>
+	
+/***** Constants	*****/
+	/**	The maximum integer value that will fit in a uint8_t data type
+		@ingroup	commonutils
+	*/
+	#define UINT8_MAXVALUE	255
+	
+	/**	The maximum integer value that will fit in a uint16_t data type
+		@ingroup	commonutils
+	*/
+	#define UINT16_MAXVALUE	0xFFFF
+	
+	/**	The maximum integer value that will fit in a uint32_t data type
+		@ingroup	commonutils
+	*/
+	#define UINT32_MAXVALUE	0xFFFFFFFF
+
+/***** Definitions	*****/
+	typedef enum eReturn_t {
+		Warn_Unknown	= 1,	/**< An unknown but recoverable error happened during the operation */
+		Success			= 0,	/**< The operation completed successfully */
+		Fail_Unknown	= -1,	/**< An unknown and unrecoverable error happened during the operation */
+		Fail_NotImplem	= -2,	/**< Function not implemented */
+		Fail_CommError	= -3,	/**< Communications layer failure */
+		Fail_Invalid	= -4,	/**< Some value provided was invalid for this operaion */
+	} eReturn_t;
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+	/**	@brief		Check if all bits set in Mask, are set in Register
+		@param		Register	The value to test
+		@param		Mask		The bits to check in the Register
+		@return		Will return true if all bits that are 1 in Mask are also 1 in Register.
+			If any 1 bits in Mask are 0 in Register will return false.
+		@ingroup	commonutils
+	*/
+	#define CheckAllBitsInMask(Register, Mask)	((((Register) & (Mask)) == (Mask)) ? true : false)
+
+	/**	@brief		Check if any bits set in Mask, are set in Register
+		@param		Register	The value to test
+		@param		Mask		The bits to check in the Register
+		@return		Will return true if any bits that are 1 in Mask 1 in Register.  If no 
+			1 bits in Mask are 1 in Register will return false.
+		@ingroup	commonutils
+	*/
+	#define CheckAnyBitsInMask(Register, Mask)	((((Register) & (Mask)) != 0) ? true : false)
+
+	/**	@brief		Gives the value from Register with the bits set in mask cleared/zeroed
+		@details	The Register value will be updated by calling this macro, its return
+			is given for convenience.  The values supplied can not 
+			exceed 32 bits.
+
+			The word Zero was used in the name instead of Clear for visual clarity
+			from the various Check macros.
+		@param		Register	The value to be updated, having specified bits cleared
+		@param		Mask		The bits to clear in Register
+		@return		The value of Register after it is updated
+		@ingroup	commonutils
+	*/
+	#ifdef __cplusplus
+		#define ZeroAllBitsInMask(Register, Mask)	Register = ((typeof(Register))(((uint32_t)Register) & (~(uint32_t)(Mask))))
+	#else
+		#define ZeroAllBitsInMask(Register, Mask)	Register = (((uint32_t)Register) & (~(uint32_t)(Mask)))
+	#endif
+
+	/**	@brief		Gives the value from Register with the bits set in mask set to 1
+		@details	The Register value will not be updated by calling this macro, its 
+			return must be stored to retain this value.  The values supplied can not 
+			exceed 32 bits.
+		@param		Register	The value to be updated, having specified bits set
+		@param		Mask		The bits to set in Register
+		@return		The value of Register after it is updated
+		@ingroup	commonutils
+	*/
+	#ifdef __cplusplus
+		#define SetAllBitsInMask(Register, Mask)	Register = ((typeof(Register))(((uint32_t)Register) | ((uint32_t)(Mask))))
+	#else
+		#define SetAllBitsInMask(Register, Mask)	Register = (((uint32_t)Register) | ((uint32_t)(Mask)))
+	#endif
+
+	/**	@brief		Returns the larger of two numeric values
+		@param		nNum1	The first number to compare
+		@param		nNum2	The second number to compare
+		@return		The larger of the two values being compared
+		@ingroup	commonutils
+	*/
+	#define GetLargerNum(nNum1, nNum2)		((nNum1 > nNum2) ? nNum1 : nNum2)
+
+	/**	@brief		Returns the smaller of two numeric values
+		@param		nNum1	The first number to compare
+		@param		nNum2	The second number to compare
+		@return		The smaller of the two values being compared
+		@ingroup	commonutils
+	*/
+	#define GetSmallerNum(nNum1, nNum2)		((nNum1 < nNum2) ? nNum1 : nNum2)
+	
+	/**	@brief		Checks if a number is within a specified range
+		@details	Tests if the number is within the bounds of the number range specified.  If the number
+			matches the bounds it is considered within the range.
+		@param		nNumber		The number to test
+		@param		nRangeMin	The minimum bound of the range
+		@param		nRangeMax	The maximum bound of the range
+		@return		True if the number is within the range, false otherwise
+		@ingroup	commonutils
+	*/
+	#define	IsNumberInInclusiveRange(nNumber, nRangeMin, nRangeMax)		(((nNumber >= nRangeMin) && (nNumber <= nRangeMax)) ? true : false)
+	
+	/**	@brief		Determines if a given number exists in an array
+		@param		nNumber		The number to check for in the array
+		@param		aList		The array to searrch through
+		@param		nListCnt	The number of elements in the array
+		@return		True if the number is found in the array, false if it is not
+		@ingroup	commonutils
+	*/
+	bool NumberInArray_u8(uint8_t nNumber, const uint8_t *aList, uint32_t nListCnt);
+	
+	/**	@brief		Determines if a given number exists in an array
+		@param		nNumber		The number to check for in the array
+		@param		aList		The array to searrch through
+		@param		nListCnt	The number of elements in the array
+		@return		True if the number is found in the array, false if it is not
+		@ingroup	commonutils
+	*/
+	bool NumberInArray_u16(uint16_t nNumber, const uint16_t *aList, uint32_t nListCnt);
+
+	/**	@brief		Determines the index of a given number in an array
+		@param		nNumber		The number to check for in the array
+		@param		aList		The array to search through
+		@param		nListCnt	The number of elements in the array
+		@return		The index if the number is found in the array, nListCnt if it is not
+		@ingroup	commonutils
+	*/
+	uint32_t IndexInArray_u8(uint8_t nNumber, const uint8_t *aList, uint32_t nListCnt);
+	
+	/**	@brief		Determines the index of a given number in an array
+		@param		nNumber		The number to check for in the array
+		@param		aList		The array to search through
+		@param		nListCnt	The number of elements in the array
+		@return		The index if the number is found in the array, nListCnt if it is not
+		@ingroup	commonutils
+	*/
+	uint32_t IndexInArray_u16(uint16_t nNumber, const uint16_t *aList, uint32_t nListCnt);
+
+	/**	@brief		Calculates an 8 bit CRC value for an array of data
+		@param		nPolynomial		The 8 bit polynomial to use while generating the CRC
+		@param		nInit			The starting value to use when generating the CRC
+		@param		nXOROut			Exclusive or the output with this value, set to 0x00 for no XOR
+		@param		pData			Pointer to the data to CRC
+		@param		nDataLen		The number of bytes in the data
+		@ingroup	commonutils
+	*/
+	uint8_t CalculateCRC8(uint8_t nPolynomial, uint8_t nInit, uint8_t nXOROut, const uint8_t *pData, uint32_t nDataLen);
+	
+	/**	@brief		Counts the 1 bits in an integer value
+		@param		nVal		The value to count the set bits in
+		@return		Count of the 1 bits in the value
+		@ingroup	commonutils
+	*/
+	uint32_t CountSetBitsInInt32(uint32_t nVal);
+	
+	/**	@brief		Counts the 1 bits in an integer value
+		@param		nVal		The value to count the set bits in
+		@return		Count of the 1 bits in the value
+		@ingroup	commonutils
+	*/
+	uint16_t CountSetBitsInInt16(uint32_t nVal);
+	
+	/**	@brief		Returns the parameter value with the bits reversed
+		@details	If the value 0xC5 (0b11000101) is passed in then the 
+			returned value will be 0xA3 (0b10100011)
+		@param		nVal		Value to reverse the bits in
+		@return		Bit reversed value
+		@ingroup	commonutils
+	*/
+	uint8_t ReverseBitsInUInt8(uint8_t nVal);
+
+/***** Functions	*****/
+
+
+#endif
+

--- a/Projects/WS2812Bled/GPIOGeneralInterface.c
+++ b/Projects/WS2812Bled/GPIOGeneralInterface.c
@@ -1,0 +1,90 @@
+/*	File:	GPIOGeneralInterface.c
+	Author:	J. Beighel
+	Date:	12-10-2020
+*/
+
+/***** Includes		*****/
+	#include "GPIOGeneralInterface.h"
+	
+/***** Definitions	*****/
+
+
+/***** Constants	*****/
+
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+	eGPIOReturn_t GPIOPortInitialize(sGPIOIface_t *pIface, void *pHWInfo);
+	
+	eGPIOReturn_t GPIOSetModeByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, eGPIOModes_t eMode);
+	
+	eGPIOReturn_t GPIOReadModeByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, eGPIOModes_t *eMode);
+	
+	eGPIOReturn_t GPIODigitalWriteByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, bool bState);
+	
+	eGPIOReturn_t GPIODigitalReadByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, bool *bState);
+	
+	eGPIOReturn_t GPIOPWMWriteByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, uint32_t nPWMValue);
+	
+	eGPIOReturn_t GPIOAnalogWriteByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, uint32_t nAnaValue);
+	
+	eGPIOReturn_t GPIOAnalogReadByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, uint32_t *nAnaValue);
+
+
+/***** Functions	*****/
+
+eGPIOReturn_t GPIOInterfaceInitialize(sGPIOIface_t *pIface) {
+	pIface->pfPortInit = &GPIOPortInitialize;
+	pIface->pfSetModeByPin = &GPIOSetModeByPin;
+	pIface->pfReadModeByPin = &GPIOReadModeByPin;
+	pIface->pfDigitalWriteByPin = &GPIODigitalWriteByPin;
+	pIface->pfDigitalReadByPin = &GPIODigitalReadByPin;
+	pIface->pfPWMWriteByPin = &GPIOPWMWriteByPin;
+	pIface->pfAnalogWriteByPin = &GPIOAnalogWriteByPin;
+	pIface->pfAnalogReadByPin = &GPIOAnalogReadByPin;
+
+	memset(pIface->aGPIO, 0, sizeof(sGPIOInfo_t) * GPIO_IOCNT);
+
+	pIface->nPWMBitDepth = 0;
+	pIface->nAnaInBitDepth = 0;
+	pIface->nAnaOutBitDepth = 0;
+	pIface->nGPIOCnt = 0;
+
+	pIface->pHWInfo = NULL;
+
+	return GPIO_Success;
+}
+
+eGPIOReturn_t GPIOPortInitialize(sGPIOIface_t *pIface, void *pHWInfo) {
+	return GPIOFail_Unsupported;
+}
+
+eGPIOReturn_t GPIOSetModeByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, eGPIOModes_t eMode) {
+	return GPIOFail_Unsupported;
+}
+
+eGPIOReturn_t GPIOReadModeByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, eGPIOModes_t *eMode) {
+	return GPIOFail_Unsupported;
+}
+
+eGPIOReturn_t GPIODigitalWriteByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, bool bState) {
+	return GPIOFail_Unsupported;
+}
+
+eGPIOReturn_t GPIODigitalReadByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, bool *bState) {
+	return GPIOFail_Unsupported;
+}
+
+eGPIOReturn_t GPIOPWMWriteByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, uint32_t nPWMValue) {
+	return GPIOFail_Unsupported;
+}
+
+eGPIOReturn_t GPIOAnalogWriteByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, uint32_t nAnaValue) {
+	return GPIOFail_Unsupported;
+}
+
+eGPIOReturn_t GPIOAnalogReadByPin(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, uint32_t *nAnaValue) {
+	return GPIOFail_Unsupported;
+}

--- a/Projects/WS2812Bled/GPIOGeneralInterface.h
+++ b/Projects/WS2812Bled/GPIOGeneralInterface.h
@@ -1,0 +1,136 @@
+/**	@defgroup	gpioiface
+	@brief		General interface for using GPIO pins
+	@details	v0.4
+	#Description
+	
+	#File Information
+		File:	GPIOGeneralInterface.h
+		Author:	J. Beighel
+		Date:	12-10-2020
+*/
+
+#ifndef __gpioiface
+	#define __gpioiface
+
+/***** Includes		*****/
+	#include <stdint.h>
+	#include <stdbool.h>
+	#include <string.h>
+
+/***** Definitions	*****/
+	
+	#ifndef GPIO_IOCNT
+		/**	@brief		Number of GPIO points to allocate space for
+			@ingroup	gpioiface
+		*/
+		#define GPIO_IOCNT		30
+	#endif
+	
+	/**	@brief		Value to use for an index to indicate this pin is not in use
+		@ingroup	gpioiface
+	*/
+	#define GPIO_NOPIN			(0xFFFF)
+	
+	typedef struct sGPIOIface_t sGPIOIface_t; //Declarign this early, will define it later
+	
+	/**	@brief		Convenience type, defines value used to identify GPIO pins
+		@ingroup	gpioiface
+	*/
+	typedef uint16_t GPIOID_t;
+		
+	typedef enum eGPIOCapabilities_t {
+		GPIOCap_None			= 0x0000,
+		GPIOCap_SetPinMode		= 0x0001,
+		GPIOCap_ReadPinMode		= 0x0002,
+		GPIOCap_DigitalWrite	= 0x0004,
+		GPIOCap_DigitalRead		= 0x0008,
+		GPIOCap_PWMWrite		= 0x0010,
+		GPIOCap_AnalogWrite		= 0x0020,
+		GPIOCap_AnalogRead		= 0x0040,
+	} eGPIOCapabilities_t;
+	
+	/**	@brief		Enumeration of all GPIO interface return values
+		@ingroup	gpioiface
+	*/
+	typedef enum eGPIOReturn_t {
+		GPIOWarn_Unknown		= 1,	/**< An unknown but recoverable error happened during the operation */
+		GPIO_Success			= 0,	/**< The operation completed successfully */
+		GPIOFail_Unknown		= -1,	/**< An unknown and unrecoverable error happened during the operation */
+		GPIOFail_Unsupported	= -2,	/**< The requested operation is not supported by this device */
+		GPIOFail_InvalidPin		= -3,	/**< The requested pin does not exist */
+		GPIOFail_InvalidMode	= -4,	/**< The requested pin mode is invalid */
+		GPIOFail_InvalidOp		= -5,	/**< A request to read or write to a GPIO in a mode that doesn't allow this */
+	} eGPIOReturn_t;
+	
+	/**	@brief		Enumeration of all possible GPIO modes
+		@ingroup	gpioiface
+	*/
+	typedef enum eGPIOModes_t {
+		GPIO_None				= 0x00,
+		GPIO_DigitalInput		= 0x01,
+		GPIO_DigitalOutput		= 0x02,
+		GPIO_OutputPWM			= 0x04,
+		GPIO_InputPullup		= 0x09,
+		GPIO_AnalogInput		= 0x10,
+		GPIO_AnalogOutput		= 0x20,
+	} eGPIOModes_t;
+
+	typedef eGPIOReturn_t (*pfGPIOPortInitialize_t)(sGPIOIface_t *pIface, void *pHWInfo);
+	
+	typedef eGPIOReturn_t (*pfGPIOSetModeByPin_t)(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, eGPIOModes_t eMode);
+	
+	typedef eGPIOReturn_t (*pfGPIOReadModeByPin_t)(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, eGPIOModes_t *eMode);
+	
+	typedef eGPIOReturn_t (*pfGPIODigitalWriteByPin_t)(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, bool bState);
+	
+	typedef eGPIOReturn_t (*pfGPIODigitalReadByPin_t)(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, bool *bState);
+	
+	typedef eGPIOReturn_t (*pfGPIOPWMWriteByPin_t)(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, uint32_t nPWMValue);
+	
+	typedef eGPIOReturn_t (*pfGPIOAnalogWriteByPin_t)(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, uint32_t nAnaValue);
+	
+	typedef eGPIOReturn_t (*pfGPIOAnalogReadByPin_t)(sGPIOIface_t *pIface, GPIOID_t nGPIOPin, uint32_t *nAnaValue);
+
+	typedef struct sGPIOInfo_t {
+		eGPIOModes_t eCapabilities;
+		eGPIOModes_t eMode;
+		
+		void *pHWInfo;
+	} sGPIOInfo_t;
+
+	typedef struct sGPIOIface_t {
+		pfGPIOPortInitialize_t pfPortInit;
+		pfGPIOSetModeByPin_t pfSetModeByPin;
+		pfGPIOReadModeByPin_t pfReadModeByPin;
+		pfGPIODigitalWriteByPin_t pfDigitalWriteByPin;
+		pfGPIODigitalReadByPin_t pfDigitalReadByPin;
+		pfGPIOPWMWriteByPin_t pfPWMWriteByPin;
+		pfGPIOAnalogWriteByPin_t pfAnalogWriteByPin;
+		pfGPIOAnalogReadByPin_t pfAnalogReadByPin;
+		
+		sGPIOInfo_t aGPIO[GPIO_IOCNT];
+		
+		uint8_t nPWMBitDepth;
+		uint8_t nAnaInBitDepth;
+		uint8_t nAnaOutBitDepth;
+		uint8_t nGPIOCnt;
+		
+		void *pHWInfo;
+	} sGPIOIface_t;
+		
+
+/***** Constants	*****/
+
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+	eGPIOReturn_t GPIOInterfaceInitialize(sGPIOIface_t *pIface);
+	
+
+/***** Functions	*****/
+
+	
+#endif
+

--- a/Projects/WS2812Bled/GPIO_Arduino.h
+++ b/Projects/WS2812Bled/GPIO_Arduino.h
@@ -1,0 +1,515 @@
+/**	@defgroup	gpioarduino
+	@brief		Implementation of the GPIO General Interface for Arduino
+	@details	v0.5
+	
+	# File Info #
+		File:	GPIO_Arduino.h
+		Author:	J. Beighel
+		Date:	2021-02-02
+*/
+
+#ifndef __GPIOARDUINO
+	#define __GPIOARDUINO
+
+/***** Includes		*****/
+	#include "CommonUtils.h"
+	#include "GPIOGeneralInterface.h"
+
+
+/***** Constants	*****/
+	/**	@brief		Default GPIO hardware information object
+		@ingroup	gpioarduino
+	*/
+	#define GPIO_HWINFO		NULL
+	
+	#define GPIO_INIT		ArduinoGPIOPortInitialize
+	
+	#define GPIO_CAPS		GPIOCap_SetPinMode | GPIOCap_ReadPinMode | GPIOCap_DigitalWrite | GPIOCap_DigitalRead | GPIOCap_PWMWrite | GPIOCap_AnalogWrite | GPIOCap_AnalogRead;
+	
+	#define TIME_INIT		ArduinoTimeIfaceInitialize
+	
+	#define TIME_CAPS		(TimeCap_GetTicks | TimeCap_DelaySec | TimeCap_DelayMilliSec | TimeCap_DelayMicroSec);
+	
+	#define DELAYMILLISEC		delay
+	
+	#define DELAYMICROSEC		delayMicroseconds
+
+	#undef ARDUINO_MODEL
+
+	//Defines for Arduino boards are found in:
+	//C:\Users\<Username>\AppData\Local\Arduino15\packages\<Vendor>\hardware\<Processor>\<Version>\boards.txt
+	//Look for the setting name that ends with .board=
+	//Prefix its value with ARDUINO_
+	#ifdef ARDUINO_AVR_UNO	//Compiling for Arduino Uno
+		#define ARDUINO_MODEL		"Arduino Uno"
+		
+		#error "Support for Arduino Uno incomplete"
+	#endif
+	
+	#ifdef ARDUINO_SAM_DUE	//Compiling for Due
+		#define ARDUINO_MODEL		"Arduino Due"
+		
+		#error "Support for Arduino Due incomplete"
+	#endif
+	
+	#ifdef ARDUINO_SAMD_NANO_33_IOT	//Compiling for Nano IoT
+		#define ARDUINO_MODEL		"Arduino Nano IoT"
+	
+		/**	@brief		Count of available GPIO pins
+			@ingroup	gpioarduino
+		*/
+		#define ARDUINO_GPIOCNT		(sizeof(gArduinoGPIOList) / sizeof(uint8_t))
+		
+		#define ARDUINO_DACCNT		(sizeof(gArduinoDACList) / sizeof(uint8_t))
+		
+		#define ARDUINO_ADCCNT		(sizeof(gArduinoADCList) / sizeof(uint8_t))
+		
+		#define ARDUINO_PWMCNT		(sizeof(gArduinoPWMList) / sizeof(uint8_t))
+		
+		/**	@brief		Available bit depth for Analog Inputs
+			@ingroup	gpioarduino
+		*/
+		#define ARDUINO_ADCBITDEPTH	12
+		
+		/**	@brief		Available bit depth for Analog Outputs
+			@details	Arduino uses this same bit depth for PWM and DAC outputs.  So the values
+				must match.
+			@ingroup	gpioarduino
+		*/
+		#define ARDUINO_DACBITDEPTH	ARDUINO_PWMBITDEPTH
+		
+		/**	@brief		Available bit depth for PWM Outputs
+			@ingroup	gpioarduino
+		*/
+		#define ARDUINO_PWMBITDEPTH	10
+		
+		/** @brief		Constant array of all pin numbers to use for GPIO
+			@details	There are 22 potential GPIO pins, owever 7 are used by the peripheral buses
+				Pin 0 and 1 are used for the UART.
+				Pin 11 is MOSI, Pin 12 is MIS and Pin 13 are SCK; reserved for SPI
+				Pin 18/A4 is SDA and Pin 19/A5 is SCL; reserved for I2C
+			@ingroup	gpioarduino
+		*/
+		const uint8_t gArduinoGPIOList[] = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 14, 15, 16, 17, 20, 21 };
+		
+		/** @brief		Constant array of all pin numbers that support Analog Input
+			@ingroup	gpioarduino
+		*/
+		const uint8_t gArduinoADCList[] = { 14, 15, 16, 17, 18, 19, 20, 21 }; //14 is A0 through 21 is A7
+		
+		/** @brief		Constant array of all pin numbers that support Analog Ouput
+			@ingroup	gpioarduino
+		*/
+		const uint8_t gArduinoDACList[] = { 14 }; //14 is A0
+		
+		/** @brief		Constant array of all pin numbers that support PWM Output
+			@ingroup	gpioarduino
+		*/
+		const uint8_t gArduinoPWMList[] = { 2, 3, 5, 6, 9, 10, 11, 12, 16, 17, 19 }; //16 is A2, 17 is A3, and 19 is A5
+	#endif
+	
+	#ifdef ARDUINO_SAMD_MKRZERO	//Compiling for Mkr Zero
+		#define ARDUINO_MODEL		"Arduino Mkr Zero"
+		
+		#error "Support for Arduino Mkr Zero incomplete"
+	#endif
+	
+	#ifdef ARDUINO_TRINKET_M0 //Compiling for Adafruit Trinket M0
+		#define ARDUINO_MODEL		"Adafruit Trinket M0"
+	
+		/** @brief    Count of available GPIO pins
+		  @ingroup  gpioarduino
+		*/
+		#define ARDUINO_GPIOCNT   (sizeof(gArduinoGPIOList) / sizeof(uint8_t))
+		
+		#define ARDUINO_DACCNT    (sizeof(gArduinoDACList) / sizeof(uint8_t))
+		
+		#define ARDUINO_ADCCNT    (sizeof(gArduinoADCList) / sizeof(uint8_t))
+		
+		#define ARDUINO_PWMCNT    (sizeof(gArduinoPWMList) / sizeof(uint8_t))
+		
+		/** @brief    Available bit depth for Analog Inputs
+		  @ingroup  gpioarduino
+		*/
+		#define ARDUINO_ADCBITDEPTH 12
+		
+		/** @brief    Available bit depth for Analog Outputs
+		  @details  Arduino uses this same bit depth for PWM and DAC outputs.  So the values
+			must match.
+		  @ingroup  gpioarduino
+		*/
+		#define ARDUINO_DACBITDEPTH ARDUINO_PWMBITDEPTH
+		
+		/** @brief    Available bit depth for PWM Outputs
+		  @ingroup  gpioarduino
+		*/
+		#define ARDUINO_PWMBITDEPTH 10
+		
+		/** @brief    Constant array of all pin numbers to use for GPIO
+		  @details  There are 5 potential GPIO pins, most are shared with the peripheral buses
+			Pin 3 is RX and 4 is TX are used for the UART.
+			Pin 0 is MOSI, Pin 1 is MISO and Pin 2 are SCK; reserved for SPI
+			Pin 0 is SDA and Pin 2 is SCL; reserved for I2C
+		  @ingroup  gpioarduino
+		*/
+		const uint8_t gArduinoGPIOList[] = { 0, 1, 2, 3, 4 };
+		
+		/** @brief    Constant array of all pin numbers that support Analog Input
+		  @ingroup  gpioarduino
+		*/
+		const uint8_t gArduinoADCList[] = { 2, 3, 4 };
+		
+		/** @brief    Constant array of all pin numbers that support Analog Ouput
+		  @ingroup  gpioarduino
+		*/
+		const uint8_t gArduinoDACList[] = {  };
+		
+		/** @brief    Constant array of all pin numbers that support PWM Output
+		  @ingroup  gpioarduino
+		*/
+		const uint8_t gArduinoPWMList[] = { 0, 1, 2, 3, 4 };
+	#endif
+	
+	#ifdef ARDUINO_NUCLEO_L412KB //Compiling for STM32 Nucleo-32 L412KB
+		#define ARDUINO_MODEL		"STM32 Nucleo-32 L412KB"
+		
+		//#error "Support for STM32 Nucleo-32 L412KB incomplete"
+		
+		/**	@brief		Count of available GPIO pins
+			@ingroup	gpioarduino
+		*/
+		#define ARDUINO_GPIOCNT		(sizeof(gArduinoGPIOList) / sizeof(uint8_t))
+		
+		#define ARDUINO_DACCNT		(sizeof(gArduinoDACList) / sizeof(uint8_t))
+		
+		#define ARDUINO_ADCCNT		(sizeof(gArduinoADCList) / sizeof(uint8_t))
+		
+		#define ARDUINO_PWMCNT		(sizeof(gArduinoPWMList) / sizeof(uint8_t))
+		
+		/**	@brief		Available bit depth for Analog Inputs
+			@ingroup	gpioarduino
+		*/
+		#define ARDUINO_ADCBITDEPTH	12
+		
+		/**	@brief		Available bit depth for Analog Outputs
+			@details	Arduino uses this same bit depth for PWM and DAC outputs.  So the values
+				must match.
+			@ingroup	gpioarduino
+		*/
+		#define ARDUINO_DACBITDEPTH	ARDUINO_PWMBITDEPTH
+		
+		/**	@brief		Available bit depth for PWM Outputs
+			@ingroup	gpioarduino
+		*/
+		#define ARDUINO_PWMBITDEPTH	10
+		
+		/** @brief		Constant array of all pin numbers to use for GPIO
+			@details	There are 22 potential GPIO pins, owever 7 are used by the peripheral buses
+				Pin 0 and 1 are used for the UART.
+				Pin 11 is MOSI, Pin 12 is MIS and Pin 13 are SCK; reserved for SPI
+				Pin 18/A4 is SDA and Pin 19/A5 is SCL; reserved for I2C
+			@ingroup	gpioarduino
+		*/
+		const uint8_t gArduinoGPIOList[] = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 14, 15, 16, 17, 20, 21 };
+		
+		/** @brief		Constant array of all pin numbers that support Analog Input
+			@ingroup	gpioarduino
+		*/
+		const uint8_t gArduinoADCList[] = { 14, 15, 16, 17, 18, 19, 20, 21 }; //14 is A0 through 21 is A7
+		
+		/** @brief		Constant array of all pin numbers that support Analog Ouput
+			@ingroup	gpioarduino
+		*/
+		const uint8_t gArduinoDACList[] = { };
+		
+		/** @brief		Constant array of all pin numbers that support PWM Output
+			@ingroup	gpioarduino
+		*/
+		const uint8_t gArduinoPWMList[] = { };
+	#endif
+	
+	#ifndef ARDUINO_MODEL
+		#error "No arduino model detected, unable to compile GPIO Interface for Arduino"
+	#endif
+
+/***** Definitions	*****/
+
+
+/***** Constants	*****/
+
+
+/***** Globals		*****/
+
+
+/***** Prototypes 	*****/
+	eGPIOReturn_t ArduinoGPIOPortInitialize(sGPIOIface_t *pIface, void *pHWInfo);
+
+	eGPIOReturn_t ArduinoGPIOSetModeByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, eGPIOModes_t eMode);
+	
+	eGPIOReturn_t ArduinoGPIOReadModeByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, eGPIOModes_t *eMode);
+	
+	eGPIOReturn_t ArduinoGPIODigitalWriteByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, bool bState);
+	
+	eGPIOReturn_t ArduinoGPIODigitalReadByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, bool *bState);
+	
+	eGPIOReturn_t ArduinoGPIOPWMWriteByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, uint32_t nPWMValue);
+	
+	eGPIOReturn_t ArduinoGPIOAnalogWriteByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, uint32_t nAnaValue);
+	
+	eGPIOReturn_t ArduinoGPIOAnalogReadByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, uint32_t *nAnaValue);
+	
+	eReturn_t ArduinoTimeIfaceInitialize(sTimeIface_t *pTime);
+	
+	uint32_t ArduinoGetTicks(void);
+	
+	eReturn_t ArduinoDelaySeconds(uint32_t nDelayAmount);
+	
+	eReturn_t ArduinoDelayMilliSeconds(uint32_t nDelayAmount);
+	
+	eReturn_t ArduinoDelayMicroSeconds(uint32_t nDelayAmount);
+	
+	eReturn_t ArduinoDelay100NanoSeconds(uint32_t nDelayAmount);
+
+/***** Functions	*****/
+
+eGPIOReturn_t ArduinoGPIOPortInitialize(sGPIOIface_t *pIface, void *pHWInfo) {
+	uint16_t nCtr;
+	uint8_t nCurrPin;
+	
+	GPIOInterfaceInitialize(pIface); //Set a base sanity for the interface
+	
+	//Set pointers for all supported functions
+	pIface->pfPortInit = &ArduinoGPIOPortInitialize;
+	pIface->pfSetModeByPin = &ArduinoGPIOSetModeByPin;
+	pIface->pfReadModeByPin = &ArduinoGPIOReadModeByPin;
+	pIface->pfDigitalWriteByPin = &ArduinoGPIODigitalWriteByPin;
+	pIface->pfDigitalReadByPin = &ArduinoGPIODigitalReadByPin;
+	pIface->pfPWMWriteByPin = &ArduinoGPIOPWMWriteByPin;
+	pIface->pfAnalogWriteByPin = &ArduinoGPIOAnalogWriteByPin;
+	pIface->pfAnalogReadByPin = &ArduinoGPIOAnalogReadByPin;
+	
+	//Provide the capabilities of the available GPIO
+	pIface->nPWMBitDepth = ARDUINO_PWMBITDEPTH;
+	pIface->nAnaInBitDepth = ARDUINO_ADCBITDEPTH;
+	pIface->nAnaOutBitDepth = ARDUINO_DACBITDEPTH;
+	
+	if (GPIO_IOCNT < ARDUINO_GPIOCNT) { //Can't provide more IO than the interface allows
+		pIface->nGPIOCnt = GPIO_IOCNT;
+	} else {
+		pIface->nGPIOCnt = ARDUINO_GPIOCNT;
+	}
+	
+	pIface->pHWInfo = pHWInfo;
+	
+	//Set the capabilities of all the IO points
+	for (nCtr = 0; nCtr < pIface->nGPIOCnt; nCtr++) {
+		pIface->aGPIO[nCtr].eCapabilities = (eGPIOModes_t)(GPIO_DigitalInput | GPIO_DigitalOutput | GPIO_InputPullup);
+		
+		if (NumberInArray_u8(gArduinoGPIOList[nCtr], gArduinoPWMList, ARDUINO_PWMCNT) == true) {
+			pIface->aGPIO[nCtr].eCapabilities = (eGPIOModes_t)(pIface->aGPIO[nCtr].eCapabilities | GPIO_OutputPWM);
+		}
+		
+		if (NumberInArray_u8(gArduinoGPIOList[nCtr], gArduinoADCList, ARDUINO_ADCCNT) == true) {
+			pIface->aGPIO[nCtr].eCapabilities = (eGPIOModes_t)(pIface->aGPIO[nCtr].eCapabilities | GPIO_AnalogInput);
+		}
+		
+		if (NumberInArray_u8(gArduinoGPIOList[nCtr], gArduinoDACList, ARDUINO_DACCNT) == true) {
+			pIface->aGPIO[nCtr].eCapabilities = (eGPIOModes_t)(pIface->aGPIO[nCtr].eCapabilities | GPIO_AnalogOutput);
+		}
+		
+		pIface->aGPIO[nCtr].eMode = GPIO_None;
+		pIface->aGPIO[nCtr].pHWInfo = (void *)gArduinoGPIOList[nCtr];
+	}
+	
+	//Initialize the necessary hardware
+	analogReadResolution(pIface->nAnaInBitDepth);
+	analogWriteResolution(pIface->nPWMBitDepth);  //Arduino uses this for PWM and DAC, so they better match
+	
+	return GPIO_Success;
+}
+	
+eGPIOReturn_t ArduinoGPIOSetModeByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, eGPIOModes_t eMode) {
+	uint8_t nIdx = IndexInArray_u8(nGPIOPin, gArduinoGPIOList, ARDUINO_GPIOCNT);
+	
+	if (nIdx >= ARDUINO_GPIOCNT) {
+		return GPIOFail_InvalidPin;
+	}
+	
+	if (CheckAllBitsInMask(pIface->aGPIO[nIdx].eCapabilities, eMode) == false) { 
+		//Some feature requested is not valid for this pin
+		return GPIOFail_Unsupported;
+	}
+	
+	if ((CountSetBitsInInt32(eMode) > 1) && (eMode != GPIO_InputPullup)) {
+		return GPIOFail_InvalidMode;
+	}
+	
+	switch (eMode) {
+		case GPIO_DigitalInput:
+			pinMode(nGPIOPin, INPUT);
+			break;
+		case GPIO_DigitalOutput:
+		case GPIO_OutputPWM: //PWM and Digital Output are handled the same
+			pinMode(nGPIOPin, OUTPUT);
+			break;
+		case GPIO_InputPullup:
+			pinMode(nGPIOPin, INPUT_PULLUP);
+			break;
+		case GPIO_AnalogInput:
+			pinMode(nGPIOPin, INPUT);
+			break;
+		case GPIO_AnalogOutput:
+			pinMode(nGPIOPin, OUTPUT);
+			break;
+		default: //Unknown or unrecognized settings
+			return GPIOFail_Unsupported;
+	}
+	
+	pIface->aGPIO[nIdx].eMode = eMode;
+	
+	return GPIO_Success;
+}
+	
+eGPIOReturn_t ArduinoGPIOReadModeByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, eGPIOModes_t *eMode) {
+	uint8_t nIdx = IndexInArray_u8(nGPIOPin, gArduinoGPIOList, ARDUINO_GPIOCNT);
+	
+	if (nIdx >= ARDUINO_GPIOCNT) {
+		return GPIOFail_InvalidPin;
+	}
+	
+	(*eMode) = pIface->aGPIO[nIdx].eMode;
+	
+	return GPIO_Success;
+}
+
+eGPIOReturn_t ArduinoGPIODigitalWriteByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, bool bState) {
+	uint8_t nIdx = IndexInArray_u8(nGPIOPin, gArduinoGPIOList, ARDUINO_GPIOCNT);
+	
+	if (nIdx >= ARDUINO_GPIOCNT) {
+		return GPIOFail_InvalidPin;
+	}
+	
+	if (pIface->aGPIO[nIdx].eMode != GPIO_DigitalOutput) {
+		return GPIOFail_InvalidOp;
+	}
+	
+	digitalWrite(nGPIOPin, bState);
+	
+	return GPIO_Success;
+}
+
+eGPIOReturn_t ArduinoGPIODigitalReadByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, bool *bState) {
+	if (digitalRead(nGPIOPin) == HIGH) {
+		*bState = true;
+	} else {
+		*bState = false;
+	}
+	
+	return GPIO_Success;
+}
+
+eGPIOReturn_t ArduinoGPIOPWMWriteByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, uint32_t nPWMValue) {
+	uint8_t nIdx = IndexInArray_u8(nGPIOPin, gArduinoGPIOList, ARDUINO_GPIOCNT);
+	
+	if (nIdx >= ARDUINO_GPIOCNT) {
+		return GPIOFail_InvalidPin;
+	}
+	
+	if (pIface->aGPIO[nIdx].eMode != GPIO_OutputPWM) {
+		return GPIOFail_InvalidOp;
+	}
+	
+	analogWrite(nGPIOPin, nPWMValue);
+	
+	return GPIO_Success;
+}
+
+eGPIOReturn_t ArduinoGPIOAnalogWriteByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, uint32_t nAnaValue) {
+	uint8_t nIdx = IndexInArray_u8(nGPIOPin, gArduinoGPIOList, ARDUINO_GPIOCNT);
+	
+	if (nIdx >= ARDUINO_GPIOCNT) {
+		return GPIOFail_InvalidPin;
+	}
+	
+	if (pIface->aGPIO[nIdx].eMode != GPIO_AnalogOutput) {
+		return GPIOFail_InvalidOp;
+	}
+	
+	analogWrite(nGPIOPin, nAnaValue);
+	
+	return GPIO_Success;
+}
+
+eGPIOReturn_t ArduinoGPIOAnalogReadByPin(sGPIOIface_t *pIface, uint16_t nGPIOPin, uint32_t *nAnaValue) {
+	uint8_t nIdx = IndexInArray_u8(nGPIOPin, gArduinoGPIOList, ARDUINO_GPIOCNT);
+	
+	if (nIdx >= ARDUINO_GPIOCNT) {
+		return GPIOFail_InvalidPin;
+	}
+	
+	if (pIface->aGPIO[nIdx].eMode != GPIO_AnalogInput) {
+		return GPIOFail_InvalidOp;
+	}
+	
+	*nAnaValue = analogRead(nGPIOPin);
+	
+	return GPIO_Success;
+}
+
+eReturn_t ArduinoTimeIfaceInitialize(sTimeIface_t *pTime) {
+	TimeInterfaceInitialize(pTime);
+	
+	pTime->pfGetTicks = &ArduinoGetTicks;
+	pTime->pfDelaySeconds = &ArduinoDelaySeconds;
+	pTime->pfDelayMilliSeconds = &ArduinoDelayMilliSeconds;
+	pTime->pfDelayMicroSeconds = &ArduinoDelayMicroSeconds;
+	pTime->pfDelay100NanoSeconds = &ArduinoDelay100NanoSeconds;
+	
+	pTime->eCapabilities = (eTimeCapabilities_t)TIME_CAPS;
+	
+	return Success;
+}
+
+uint32_t ArduinoGetTicks(void) {
+	return millis();
+}
+
+eReturn_t ArduinoDelaySeconds(uint32_t nDelayAmount) {
+	delay(1000 * nDelayAmount);
+	
+	return Success;
+}
+
+eReturn_t ArduinoDelayMilliSeconds(uint32_t nDelayAmount) {
+	delay(nDelayAmount);
+	
+	return Success;
+}
+
+eReturn_t ArduinoDelayMicroSeconds(uint32_t nDelayAmount) {
+	delayMicroseconds(nDelayAmount);
+	
+	return Success;
+}
+
+eReturn_t ArduinoDelay100NanoSeconds(uint32_t nDelayAmount) {
+	uint32_t nCtr;
+	
+	//The SAMD processors run at 46 Mhz, so each instruction is ~20 nSec
+	//5 instuctions per loop = 100 nSec each loop
+	asm volatile(
+		"MOV %0, #0;" //Initialzie the counter
+		"nsecdelay%=:"	//Local Label 1
+		"ADD %0, %0, #1;" //Increment the counter
+		"CMP %0, %1;" //Comparison to set flags
+		"NOP;"
+		"BNE nsecdelay%=;" //Jump to label 1 if zero flag not set
+		: "=r" (nCtr) //Outputs
+		: "r" (nDelayAmount) //Inputs
+		: //Clobbers
+	);
+	
+	return Success;
+}
+
+#endif

--- a/Projects/WS2812Bled/TimeGeneralInterface.c
+++ b/Projects/WS2812Bled/TimeGeneralInterface.c
@@ -1,0 +1,52 @@
+/**	File:	TimeGeneralInterface.c
+	Author:	J. Beighel
+	Date:	2021-02-02
+*/
+
+/*****	Includes	*****/
+	#include "TimeGeneralInterface.h"
+
+/*****	Defines		*****/
+
+
+/*****	Definitions	*****/
+
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	/**	@brief		Get current ticks not implemented
+		@ingroup	timeiface
+	*/
+	uint32_t TimeCurrentTicksNotImplemented(void);
+	
+	/**	@brief		Delay not implemented
+		@ingroup	timeiface
+	*/
+	eReturn_t TimeDelayNotImplemented(uint32_t nDelayAmount);
+
+/*****	Functions	*****/
+
+eReturn_t TimeInterfaceInitialize(sTimeIface_t *pIface) {
+	pIface->pfGetTicks = &TimeCurrentTicksNotImplemented;
+	pIface->pfDelaySeconds = &TimeDelayNotImplemented;
+	pIface->pfDelayMilliSeconds = &TimeDelayNotImplemented;
+	pIface->pfDelayMicroSeconds = &TimeDelayNotImplemented;
+	pIface->pfDelay100NanoSeconds = &TimeDelayNotImplemented;
+	
+	pIface->eCapabilities = TimeCap_None;
+	
+	return Success;
+}
+	
+uint32_t TimeCurrentTicksNotImplemented(void) {
+	return 0;
+}
+
+eReturn_t TimeDelayNotImplemented(uint32_t nDelayAmount) {
+	return Fail_NotImplem;
+}

--- a/Projects/WS2812Bled/TimeGeneralInterface.h
+++ b/Projects/WS2812Bled/TimeGeneralInterface.h
@@ -1,0 +1,115 @@
+/**	@defgroup	timeiface
+	@brief		General interface for basic time functions
+	@details	v0.2
+	# Intent #
+		This module is to create a common interface to provide basic time functions.  
+		Applications that need time functions can use this interface to access this 
+		functionality wihtout environment or processor dependencies.
+		
+		The interface itself will provide no functionality, it only offers a standardized 
+		set of functions to use for time management.  Each environemnt will require 
+		its own implementation of these functions.
+		
+	# Usage #
+		Each processor or environment that will support this interface must create 
+		its own copies of the interface functions.
+
+		Each implementation must call TimeInterfaceInitialize() to ensure that the
+		time interface object has correct definitions for each function pointer.  
+		This will give each function a valid definition so that accidental calls 
+		to non-implemented functions won't cause a crash.
+
+		In addition the implementation must define a value to reach the
+		TimeInterfaceInitialize() function. This should be called via a definition
+		of TIME_INIT.
+
+		Having these defined gives a very consistent and generic means of establishing
+		the interface object in the application that looks like this:
+
+		sTimeIface_t TimeObj;
+
+		TIME_INIT(&TimeObj);
+
+		The last thing the driver must do is create a define of the capabilities that
+		it provides.  This define should be options from the eTimeCapabilities_t 
+		enumeration ORed together.  This value should be a define of TIME_CAPS.  The 
+		application can check the to see if the implementation has the capabilities 
+		it requires by checking this defined value.
+		
+	#File Information
+		File:	TimeGeneralInterface.h
+		Author:	J. Beighel
+		Date:	2021-02-02
+*/
+
+#ifndef __TIMEIFACE
+	#define __TIMEIFACE
+
+/*****	Includes	*****/
+	#include <stdint.h>
+	#include <stdbool.h>
+	
+	#include "CommonUtils.h"
+
+/*****	Defines		*****/
+
+
+/*****	Definitions	*****/
+	typedef struct sTimeIface_t sTimeIface_t;
+
+	/**	@brief		Enumeration of time interface capabilities
+		@ingroup	timeiface
+	*/
+	typedef enum eTimeCapabilities_t {
+		TimeCap_None			= 0x0000,	/**< No capabilities */
+		TimeCap_GetTicks		= 0x0001,	/**< Can return a system tick count */
+		TimeCap_DelaySec		= 0x0002,	/**< Can Delay for seconds */
+		TimeCap_DelayMilliSec	= 0x0004,	/**< Can delay for milliseconds */
+		TimeCap_DelayMicroSec	= 0x0008,	/**< Can delay for microseconds */
+		TimeCap_Delay100NanoSec	= 0x0010,	/**< Can delay for 100s of nanoseconds */
+	} eTimeCapabilities_t;
+	
+	/**	@brief		Function type to use in order to get the current system tick count
+		@return		The current cound of system ticks, this number will overflow and wrap 
+						at some point
+		@ingroup	gpioiface
+	*/
+	typedef uint32_t (*pfGetCurrentTicks_t)(void);
+	
+	/**	@brief		Function type to use in order to delay for a specified time period
+		@details	The time period can be in any units
+		@param		nDelayTime		Number of milliseconds to delay for
+		@ingroup	gpioiface
+	*/
+	typedef eReturn_t (*pfTimeDelay_t)(uint32_t nDelayAmount);
+	
+	typedef eReturn_t (*pfTimeIfaceInitialize_t)(sTimeIface_t *pTime);
+	
+	/**	@brief		Interface object for time methods
+		@ingroup	timeiface
+	*/
+	typedef struct sTimeIface_t {
+		pfGetCurrentTicks_t pfGetTicks;		/**< Function pointer for getting tick count */
+		pfTimeDelay_t pfDelaySeconds;		/**< Function pointer for delay by seconds */
+		pfTimeDelay_t pfDelayMilliSeconds;	/**< Function pointer for delay by milliseconds */
+		pfTimeDelay_t pfDelayMicroSeconds;	/**< Function pointer for delay by microseconds */
+		pfTimeDelay_t pfDelay100NanoSeconds;	/**< Function pointer for delay by 100s nanoseconds */
+		
+		eTimeCapabilities_t eCapabilities;	/**< Capabilities of this implementation */
+	} sTimeIface_t;
+	
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	eReturn_t TimeInterfaceInitialize(sTimeIface_t *pIface);
+
+/*****	Functions	*****/
+
+
+#endif
+

--- a/Projects/WS2812Bled/WS2812BDriver.c
+++ b/Projects/WS2812Bled/WS2812BDriver.c
@@ -1,0 +1,84 @@
+/**	File:	WS2812BDriver.c
+	Author:	J. Beighel
+	Date:	2021-02-02
+*/
+
+/*****	Includes	*****/
+
+
+/*****	Defines		*****/
+
+
+/*****	Definitions	*****/
+
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	WS2812BPositionRedByte(eOrder, nRed)		((nRed & WS2812B_ColorMask) << ((eOrder & WS2812B_ROrderMask) >> WS2812B_ROrderShift))
+	
+	WS2812BPositionBlueByte(eOrder, nBlue)		((nBlue & WS2812B_ColorMask) << ((eOrder & WS2812B_BOrderMask) >> WS2812B_BOrderShift))
+	
+	WS2812BPositionGreenByte(eOrder, nGreen)	((nGreen & WS2812B_ColorMask) << ((eOrder & WS2812B_GOrderMask) >> WS2812B_GOrderShift))
+
+/*****	Functions	*****/
+eWS2812BReturn_t WS2812BInitialize(sWS2812BInfo_t *pDev, sTimeIface_t *pTime, sGPIOIface_t * pGPIO, GPIOID_t nCtrlPin) {
+	pDev->pTime = pTime;
+	pDev->pGpio = pGPIO;
+	pDev->nPinNum = nCtrlPin;
+	pDev->eOrder = WS2812B_BRGOrder;
+	
+	memset(pDev->anLights, 0, sizeof(uint32_t) * 64);
+	
+	return Success;
+}
+
+eWS2812BReturn_t WS2812BSetLightColor(sWS2812BInfo_t *pDev, uint32_t nLightID, uint8_t nRed, uint8_t nGree, uint8_t nBlue) {
+	uint32_t nLightVal = 0;
+	
+	nLightVal |= WS2812BPositionRedByte(pDev->eOrder, nRed);
+	nLightVal |= WS2812BPositionGreenByte(pDev->eOrder, nGreen);
+	nLightVal |= WS2812BPositionBlueByte(pDev->eOrder, nBlue);
+	
+	pDev->anLights[nLightID] = nLightVal;
+	
+	return Success;
+}
+
+eWS2812BReturn_t WS2812BUpdateLights(sWS2812BInfo_t *pDev) {
+	uint32_t nBitCtr; nLightCtr, nValue;
+	
+	//The LED's require pretty good timing, so this block can't really be
+	//Interrupted without screwing up some of the lights
+	
+	for (nLightCtr = 0; nLightCtr < 64; nLightCtr++) {
+		nValue = pDev->anLights[nLightCtr];
+		
+		for (nBitCtr = 0; nBitCtr < WS2812B_NumBits; nBitCtr++) {
+			//Sending the high bit first, 
+			if ((nValue & (0x01 << (WS2812B_NumBits - 1))) == 0) { //Use zero timing
+				//Set pin high
+				pDev->pGpio->pfGPIODigitalWriteByPin_t(pDev->pGpio, pDev->nPinNum, true);
+				pDev->pTime->pfDelay100NanoSeconds(WS2812B_0High100NSec);
+				//Set pin low
+				pDev->pGpio->pfGPIODigitalWriteByPin_t(pDev->pGpio, pDev->nPinNum, false);
+				pDev->pTime->pfDelay100NanoSeconds(WS2812B_0Low100NSec);
+			} else { //Use 1 timing
+				//Set pin high
+				pDev->pGpio->pfGPIODigitalWriteByPin_t(pDev->pGpio, pDev->nPinNum, true);
+				pDev->pTime->pfDelay100NanoSeconds(WS2812B_1High100NSec);
+				//Set pin low
+				pDev->pGpio->pfGPIODigitalWriteByPin_t(pDev->pGpio, pDev->nPinNum, false);
+				pDev->pTime->pfDelay100NanoSeconds(WS2812B_1Low100NSec);
+			}
+			
+			nValue <<= 1; //Sending from highest bit to lowest
+		}
+	}
+	
+	return Success;
+}

--- a/Projects/WS2812Bled/WS2812BDriver.c
+++ b/Projects/WS2812Bled/WS2812BDriver.c
@@ -4,7 +4,7 @@
 */
 
 /*****	Includes	*****/
-
+	#include "WS2812BDriver.h"
 
 /*****	Defines		*****/
 
@@ -19,11 +19,11 @@
 
 
 /*****	Prototypes 	*****/
-	WS2812BPositionRedByte(eOrder, nRed)		((nRed & WS2812B_ColorMask) << ((eOrder & WS2812B_ROrderMask) >> WS2812B_ROrderShift))
+	#define WS2812BPositionRedByte(eOrder, nRed)		((nRed & WS2812B_ColorMask) << ((eOrder & WS2812B_ROrderMask) >> WS2812B_ROrderShift))
 	
-	WS2812BPositionBlueByte(eOrder, nBlue)		((nBlue & WS2812B_ColorMask) << ((eOrder & WS2812B_BOrderMask) >> WS2812B_BOrderShift))
+	#define WS2812BPositionBlueByte(eOrder, nBlue)		((nBlue & WS2812B_ColorMask) << ((eOrder & WS2812B_BOrderMask) >> WS2812B_BOrderShift))
 	
-	WS2812BPositionGreenByte(eOrder, nGreen)	((nGreen & WS2812B_ColorMask) << ((eOrder & WS2812B_GOrderMask) >> WS2812B_GOrderShift))
+	#define WS2812BPositionGreenByte(eOrder, nGreen)	((nGreen & WS2812B_ColorMask) << ((eOrder & WS2812B_GOrderMask) >> WS2812B_GOrderShift))
 
 /*****	Functions	*****/
 eWS2812BReturn_t WS2812BInitialize(sWS2812BInfo_t *pDev, sTimeIface_t *pTime, sGPIOIface_t * pGPIO, GPIOID_t nCtrlPin) {
@@ -32,12 +32,13 @@ eWS2812BReturn_t WS2812BInitialize(sWS2812BInfo_t *pDev, sTimeIface_t *pTime, sG
 	pDev->nPinNum = nCtrlPin;
 	pDev->eOrder = WS2812B_BRGOrder;
 	
+	pDev->nLightNum = 5;
 	memset(pDev->anLights, 0, sizeof(uint32_t) * 64);
 	
 	return Success;
 }
 
-eWS2812BReturn_t WS2812BSetLightColor(sWS2812BInfo_t *pDev, uint32_t nLightID, uint8_t nRed, uint8_t nGree, uint8_t nBlue) {
+eWS2812BReturn_t WS2812BSetLightColor(sWS2812BInfo_t *pDev, uint32_t nLightID, uint8_t nRed, uint8_t nGreen, uint8_t nBlue) {
 	uint32_t nLightVal = 0;
 	
 	nLightVal |= WS2812BPositionRedByte(pDev->eOrder, nRed);
@@ -50,35 +51,38 @@ eWS2812BReturn_t WS2812BSetLightColor(sWS2812BInfo_t *pDev, uint32_t nLightID, u
 }
 
 eWS2812BReturn_t WS2812BUpdateLights(sWS2812BInfo_t *pDev) {
-	uint32_t nBitCtr; nLightCtr, nValue;
+	uint32_t nBitCtr, nLightCtr, nValue;
 	
 	//The LED's require pretty good timing, so this block can't really be
 	//Interrupted without screwing up some of the lights
 	
-	for (nLightCtr = 0; nLightCtr < 64; nLightCtr++) {
+	for (nLightCtr = 0; nLightCtr < pDev->nLightNum; nLightCtr++) {
 		nValue = pDev->anLights[nLightCtr];
 		
-		for (nBitCtr = 0; nBitCtr < WS2812B_NumBits; nBitCtr++) {
+		for (nBitCtr = 0; nBitCtr < WS2812B_NumBits; nBitCtr++) {			
 			//Sending the high bit first, 
 			if ((nValue & (0x01 << (WS2812B_NumBits - 1))) == 0) { //Use zero timing
 				//Set pin high
-				pDev->pGpio->pfGPIODigitalWriteByPin_t(pDev->pGpio, pDev->nPinNum, true);
+				pDev->pGpio->pfDigitalWriteByPin(pDev->pGpio, pDev->nPinNum, true);
 				pDev->pTime->pfDelay100NanoSeconds(WS2812B_0High100NSec);
 				//Set pin low
-				pDev->pGpio->pfGPIODigitalWriteByPin_t(pDev->pGpio, pDev->nPinNum, false);
+				pDev->pGpio->pfDigitalWriteByPin(pDev->pGpio, pDev->nPinNum, false);
 				pDev->pTime->pfDelay100NanoSeconds(WS2812B_0Low100NSec);
 			} else { //Use 1 timing
 				//Set pin high
-				pDev->pGpio->pfGPIODigitalWriteByPin_t(pDev->pGpio, pDev->nPinNum, true);
+				pDev->pGpio->pfDigitalWriteByPin(pDev->pGpio, pDev->nPinNum, true);
 				pDev->pTime->pfDelay100NanoSeconds(WS2812B_1High100NSec);
 				//Set pin low
-				pDev->pGpio->pfGPIODigitalWriteByPin_t(pDev->pGpio, pDev->nPinNum, false);
+				pDev->pGpio->pfDigitalWriteByPin(pDev->pGpio, pDev->nPinNum, false);
 				pDev->pTime->pfDelay100NanoSeconds(WS2812B_1Low100NSec);
 			}
 			
 			nValue <<= 1; //Sending from highest bit to lowest
 		}
 	}
+	
+	//Delay to reset addressing
+	pDev->pTime->pfDelayMicroSeconds(WS2812B_ResetUSec);
 	
 	return Success;
 }

--- a/Projects/WS2812Bled/WS2812BDriver.h
+++ b/Projects/WS2812Bled/WS2812BDriver.h
@@ -1,0 +1,70 @@
+/**	@defgroup	GROUPNAME
+	@brief		
+	@details	v
+	#Description
+	
+	#File Information
+		File:	WS2812BDriver.h
+		Author:	J. Beighel
+		Date:	2021-02-02
+*/
+
+#ifndef __WS2812BDriver_H
+	#define __WS2812BDriver_H
+
+/*****	Includes	*****/
+	#include "CommonUtils.h"
+	#include "GPIOGeneralInterface.h"
+
+/*****	Defines		*****/
+	#define WS2812B_0High100NSec	400
+	#define WS2812B_0Low100NSec		800
+	#define WS2812B_1High100NSec	800
+	#define WS2812B_1Low100NSec		400
+	
+	#define WS2812B_ResetUSec		50
+
+/*****	Definitions	*****/
+	typedef eReturn_t	eWS2812BReturn_t;
+	
+	typedef enum eWS2812BLight_t {
+		WS2812B_BOrderMask			= 0x00FF0000,	/**< Mask of order to get Blue bytes */
+		WS2812B_BOrderShift			= 16,			/**< Number of LShifts to get Blue order */
+		WS2812B_ROrderMask			= 0x0000FF00,
+		WS2812B_ROrderShift			= 8,
+		WS2812B_GOrderMask			= 0x000000FF,
+		WS2812B_GOrderShift			= 0,
+		
+		WS2812B_BRGOrder			= 0x00100800,	/**< Bit shifts to position RGB bytes in BRG order */
+		
+		WS2812B_ColorMask			= 0xFF,
+		
+		WS2812B_NumBits				= 24,			/**< Number of bits to send for each LED */
+	} eWS2812BLight_t;
+	
+	typedef struct sWS2812BInfo_t {
+		sTimeIface_t *pTime;		/**< Pointer to time interface */
+		sGPIOIface_t *pGpio;		/**< Pointer to GPIO interface */
+		GPIOID_t nPinNum;			/**< Pin connected to light string */
+		eWS2812BLight_t eOrder;		/**< Light order to use for this set */
+		uint32_t anLights[64];		/**< Array of light colors to write */
+	} sWS2812BInfo_t;
+
+/*****	Constants	*****/
+
+
+/*****	Globals		*****/
+
+
+/*****	Prototypes 	*****/
+	eWS2812BReturn_t WS2812BInitialize(sWS2812BInfo_t *pDev, sTimeIface_t *pTime, sGPIOIface_t * pGPIO, GPIOID_t nCtrlPin);
+	
+	eWS2812BReturn_t WS2812BSetLightColor(sWS2812BInfo_t *pDev, uint32_t nLightID, uint8_t nRed, uint8_t nGree, uint8_t nBlue);
+	
+	eWS2812BReturn_t WS2812BUpdateLights(sWS2812BInfo_t *pDev);
+
+/*****	Functions	*****/
+
+
+#endif
+

--- a/Projects/WS2812Bled/WS2812BDriver.h
+++ b/Projects/WS2812Bled/WS2812BDriver.h
@@ -14,13 +14,14 @@
 
 /*****	Includes	*****/
 	#include "CommonUtils.h"
+	#include "TimeGeneralInterface.h"
 	#include "GPIOGeneralInterface.h"
 
 /*****	Defines		*****/
-	#define WS2812B_0High100NSec	400
-	#define WS2812B_0Low100NSec		800
-	#define WS2812B_1High100NSec	800
-	#define WS2812B_1Low100NSec		400
+	#define WS2812B_0High100NSec	4 //400
+	#define WS2812B_0Low100NSec		8 //800
+	#define WS2812B_1High100NSec	8 //800
+	#define WS2812B_1Low100NSec		4 //400
 	
 	#define WS2812B_ResetUSec		50
 
@@ -47,6 +48,7 @@
 		sGPIOIface_t *pGpio;		/**< Pointer to GPIO interface */
 		GPIOID_t nPinNum;			/**< Pin connected to light string */
 		eWS2812BLight_t eOrder;		/**< Light order to use for this set */
+		uint32_t nLightNum;			/**< Number of lights being controlled */
 		uint32_t anLights[64];		/**< Array of light colors to write */
 	} sWS2812BInfo_t;
 

--- a/Projects/WS2812Bled/WS2812Bled.ino
+++ b/Projects/WS2812Bled/WS2812Bled.ino
@@ -44,12 +44,36 @@ void setup() {
 }
 
 void loop() {
+  /*
   WS2812BSetLightColor(&gLED, 0, 255, 255, 255);
   WS2812BSetLightColor(&gLED, 1, 0, 0, 255);
   WS2812BSetLightColor(&gLED, 2, 0, 255, 0);
   WS2812BSetLightColor(&gLED, 3, 255, 0, 0);
 
   WS2812BUpdateLights(&gLED);  
+  */
+  digitalWrite(PIN_LEDCTRL, HIGH);
+  digitalWrite(PIN_LEDCTRL, LOW);
+  digitalWrite(PIN_LEDCTRL, HIGH);
+  digitalWrite(PIN_LEDCTRL, LOW);
+  delayMicroseconds(1);
+
+  gGPIO.pfDigitalWriteByPin(&gGPIO, PIN_LEDCTRL, true);
+  gGPIO.pfDigitalWriteByPin(&gGPIO, PIN_LEDCTRL, false);
+  gGPIO.pfDigitalWriteByPin(&gGPIO, PIN_LEDCTRL, true);
+  gGPIO.pfDigitalWriteByPin(&gGPIO, PIN_LEDCTRL, false);
+  delayMicroseconds(1);
+
+  gGPIO.pfDigitalWriteByPin(&gGPIO, PIN_LEDCTRL, true);
+  gTime.pfDelay100NanoSeconds(1);
+  gGPIO.pfDigitalWriteByPin(&gGPIO, PIN_LEDCTRL, false);
+  gTime.pfDelay100NanoSeconds(1);
+  gGPIO.pfDigitalWriteByPin(&gGPIO, PIN_LEDCTRL, true);
+  gTime.pfDelay100NanoSeconds(1);
+  gGPIO.pfDigitalWriteByPin(&gGPIO, PIN_LEDCTRL, false);
+  delayMicroseconds(1);
+
+  delay(10);
   
   return;
 }

--- a/Projects/WS2812Bled/WS2812Bled.ino
+++ b/Projects/WS2812Bled/WS2812Bled.ino
@@ -1,0 +1,59 @@
+//----- Include files     -----//
+  //General libraries
+  #include "CommonUtils.h"
+  #include "CommonUtils.c"
+  #include "TimeGeneralInterface.h"
+  #include "TimeGeneralInterface.c"
+  #include "GPIOGeneralInterface.h"
+  #include "GPIOGeneralInterface.c"
+
+  //Arduino libraries
+  #include "GPIO_Arduino.h"
+
+  //Peripheral libraries
+  #include "WS2812BDriver.h"
+  #include "WS2812BDriver.c"
+
+//----- Constants         -----//
+  #define PIN_LEDCTRL    3
+
+//----- Definitions       -----//
+
+//----- Globals           -----//
+  //General interface objects
+  sTimeIface_t gTime;
+  sGPIOIface_t gGPIO;
+  
+  //Peripheral objects
+  sWS2812BInfo_t gLED;
+  
+//----- Arduino Functions -----//
+void setup() {
+  //Arduino hardware setup
+  Serial.begin(9600);
+
+  //General Interface setup
+  TIME_INIT(&gTime);
+  GPIO_INIT(&gGPIO, GPIO_HWINFO);
+
+  //Peripheral setup
+  gGPIO.pfSetModeByPin(&gGPIO, PIN_LEDCTRL, GPIO_DigitalOutput);
+  WS2812BInitialize(&gLED, &gTime, &gGPIO, PIN_LEDCTRL);
+
+  return;
+}
+
+void loop() {
+  WS2812BSetLightColor(&gLED, 0, 255, 255, 255);
+  WS2812BSetLightColor(&gLED, 1, 0, 0, 255);
+  WS2812BSetLightColor(&gLED, 2, 0, 255, 0);
+  WS2812BSetLightColor(&gLED, 3, 255, 0, 0);
+
+  WS2812BUpdateLights(&gLED);  
+  
+  return;
+}
+
+//----- Callback Functions -----//
+
+//----- Application Code   -----//


### PR DESCRIPTION
Testing proved that the pulse timing needed for the WS2812B lights could not be achieved using GPIO.  Instead the driver for the APA102 addressable LED was converted to the general interface library.